### PR TITLE
CouchDB -> PostgreSQL Migration Plan

### DIFF
--- a/doc/couchdb-pgsql-migration-plan.md
+++ b/doc/couchdb-pgsql-migration-plan.md
@@ -88,7 +88,8 @@ The clock for downtime starts as soon the following batch of `chef-client` runs 
    _This applies to the internal and external nodes referenced above._
 
    ```bash
-   sudo chef-client
+   # $OPS_ENV is the same as above: rs-prod or rs-preprod
+   sudo chef-client -o "role[$OPS_ENV],recipe[opscode-lb::lua_scripts]"
    ```
 
 ## 1.2 Migration
@@ -139,5 +140,6 @@ The clock for downtime starts as soon the following batch of `chef-client` runs 
 1. Run `chef-client` on all the `opscode-lb` Nodes
 
    ```bash
-   sudo chef-client
+   # $OPS_ENV is the same as above: rs-prod or rs-preprod
+   sudo chef-client -o "role[$OPS_ENV],recipe[opscode-lb::lua_scripts]"
    ```


### PR DESCRIPTION
## Overview

This is a first pass of a v0 migration plan for migrating a single organization from `couchdb` to `postgresql`.

You can view the doc in it's current state [here](https://github.com/opscode/oc_erchef/blob/sd/couchdb-migration-plan/doc/couchdb-pgsql-migration-plan.md).
## Issues

The migration portion of the document is likely no longer functional. @marcparadise is currently working on changes to `moser` to implement single-org migration.
