### PR TITLE
add notes on how to build feature branches of oc_erchef

### DIFF
--- a/doc/oc_erchef-build-guide.org
+++ b/doc/oc_erchef-build-guide.org
@@ -25,7 +25,7 @@ for oc_erchef tested in CI.
    should be based off of the opc-11-int branch in opscode-omnibus.
 
 5. [[Trigger build]] of custom branch of opscode-omnibus project in
-   andra.opscode.us using the [[http://andra.ci.opscode.us/job/private-chef-trigger-ad-hoc/][private-chef-trigger-ad-hoc]] job.
+   andra.ci.opscode.us using the [[http://andra.ci.opscode.us/job/private-chef-trigger-ad-hoc/][private-chef-trigger-ad-hoc]] job.
 
 * Coffee
 


### PR DESCRIPTION
This is a first pass at instructions and overview of how to put feature branches of oc_erchef through CI.
