### PR TITLE
Convert to envy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,9 @@
         {oc_chef_wm, ".*",
          {git, "git@github.com:opscode/oc_chef_wm.git",  {branch, "master"}}},
         {eper, ".*",
-         {git, "git://github.com/massemanet/eper.git", {branch, "master"}}}
+         {git, "git://github.com/massemanet/eper.git", {branch, "master"}}},
+        {envy, ".*",
+         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
        ]}.
 
 %% Plugin usage


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
