### PR TITLE
remove global default hash type for user pass encrpytion

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,8 +20,6 @@
 {cover_enabled, true}.
 
 {erl_opts, [{d, 'OC_CHEF'},
-            {d, 'DEFAULT_HASH_TYPE', 'bcrypt'},
-            {d, 'MIGRATION_HASH_TYPE', 'SHA1-bcrypt'},
             {d, 'BASE_RESOURCE', oc_chef_wm_base},
             {d, 'BASE_ROUTES', oc_chef_wm_routes},
             {d, 'CHEF_DB_DARKLAUNCH', xdarklaunch_req},


### PR DESCRIPTION
 @opscode/server-team - merging this shortly

Since chef_wm is not backward compatible prior to users changes, there is
no benefit to continuing to support two different names for the same
salt/hash scheme.
