### PR TITLE
`Yajl::Parser` is dead...long live `Chef::JSONCompact`

### DIFF
--- a/jenkins/builder_info.rb
+++ b/jenkins/builder_info.rb
@@ -1,13 +1,13 @@
 #!/opt/chef/embedded/bin/ruby
 
 require 'rubygems'
-require 'yajl'
+require 'chef/json_compat'
 
 class OhNo
   def ohai
     if !@ohai
       raw = `ohai -lerror`
-      @ohai = Yajl::Parser.new.parse(raw)
+      @ohai = Chef::JSONCompat.parse(raw)
     end
     @ohai
   end


### PR DESCRIPTION
Recent versions of the Chef no longer ship with the `yajl` gem. This has been replaced with `ffi-yajl`. It's safer to use `Chef::JSONCompact` though as this class acts as an abstraction layer over the underlying JSON parser impelmentation.

/cc @chef/server-team @jtimberman @scotthain @seth 