### PR TITLE
Ma/add read only group

### DIFF
--- a/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
+++ b/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
@@ -37,7 +37,7 @@
                      groups, nodes, roles, sandboxes, policies,
                      cookbook_artifacts]).
 
--define(GROUPS, [admins, 'billing-admins', clients, users]).
+-define(GROUPS, [admins, 'billing-admins', clients, users, 'read-only-users']).
 
 -define(ALL_PERMS, [create, read, update, delete, grant]).
 
@@ -88,7 +88,7 @@
 
            %% Admins
            {add_acl,
-            [mk_tl(container, ?CONTAINERS), mk_tl(group, [admins, clients, users]), {organization}],
+            [mk_tl(container, ?CONTAINERS), mk_tl(group, [admins, clients, users, 'read-only-users']), {organization}],
             ?ALL_PERMS, [{group, admins}]},
 
            %% users
@@ -98,6 +98,12 @@
            {add_acl, [{container, clients}], [read, delete], [{group, users}]},
            {add_acl, [mk_tl(container, [groups, containers]), {organization}], [read], [{group, users}]},
            {add_acl, [{container, sandboxes}], [create], [{group, users}]},
+
+           %% read only users
+           {add_acl,
+            [mk_tl(container, [cookbooks, data, nodes, roles, environments, policies, cookbook_artifacts, clients, groups, containers])],
+            [read], [{group, 'read-only-users'}]},
+           {add_acl, [{organization}], [read], [{group, 'read-only-users'}]},
 
            %% clients
            {add_acl, [{container, nodes}], [read, create], [{group, clients}]},

--- a/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
+++ b/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
@@ -95,8 +95,6 @@
            {add_acl,
             [mk_tl(container, [cookbooks, data, nodes, roles, environments, policies, cookbook_artifacts])],
             [create, read, update, delete], [{group, users}]},
-           {add_acl, [{container, policies}], [read], [{group, clients}]},
-           {add_acl, [{container, cookbook_artifacts}], [read], [{group, clients}]},
            {add_acl, [{container, clients}], [read, delete], [{group, users}]},
            {add_acl, [mk_tl(container, [groups, containers]), {organization}], [read], [{group, users}]},
            {add_acl, [{container, sandboxes}], [create], [{group, users}]},
@@ -104,7 +102,9 @@
            %% clients
            {add_acl, [{container, nodes}], [read, create], [{group, clients}]},
            {add_acl, [{container, data}], [read], [{group, clients}]},
-           {add_acl, mk_tl(container, [cookbooks, environments, roles]), [read] , [{group, clients}]}
+           {add_acl, mk_tl(container, [cookbooks, environments, roles]), [read] , [{group, clients}]},
+           {add_acl, [{container, policies}], [read], [{group, clients}]},
+           {add_acl, [{container, cookbook_artifacts}], [read], [{group, clients}]}
           ]
          }
         ]).


### PR DESCRIPTION
Here's a quick hack to add read only groups. WIP, Needs pedant tests and probably some migration tooling to coerce existing orgs into having this group. 