### PR TITLE
Ensure that search respects ACLs

### DIFF
--- a/apps/chef_db/priv/pgsql_statements.config
+++ b/apps/chef_db/priv/pgsql_statements.config
@@ -48,6 +48,9 @@
 {list_node_ids_names_for_org,
  <<"SELECT id, name FROM nodes WHERE org_id = $1">>}.
 
+{bulk_get_node_authz_ids,
+ <<"SELECT id, authz_id FROM nodes WHERE id = ANY($1)">>}.
+
 %% bulk_get_nodes query used for fetching nodes returned from
 %% search; only returns the gzip JSON data.  If a node has been
 %% deleted, you may get back fewer than X nodes and you won't know
@@ -77,6 +80,9 @@
 
 {list_role_ids_names_for_org,
  <<"SELECT id, name FROM roles WHERE org_id = $1">>}.
+
+{bulk_get_role_authz_ids,
+ <<"SELECT id, authz_id FROM roles WHERE id = ANY($1)">>}.
 
 %% bulk_get_roles query used for fetching roles returned from
 %% search only returns the gzip JSON data.  If a role has been
@@ -164,6 +170,9 @@
 {list_environment_ids_names_for_org,
  <<"SELECT id, name FROM environments WHERE org_id = $1">>}.
 
+{bulk_get_environment_authz_ids,
+ <<"SELECT id, authz_id FROM environments WHERE id = ANY($1)">>}.
+
 %% bulk_get_environments query used for fetching environments returned
 %% from search only returns the gzip JSON data.  If a environment has
 %% been deleted, you may get back fewer than X environments and you
@@ -198,6 +207,9 @@
 {list_client_ids_names_for_org,
  <<"SELECT id, name FROM clients WHERE org_id = $1">>}.
 
+{bulk_get_client_authz_ids,
+ <<"SELECT id, authz_id FROM clients WHERE id = ANY($1)">>}.
+
 %% bulk_get_clients query used for fetching clients returned from
 %% search returns the minimum fields needed to construct a client
 %% search response since there is no serialized object.  Note for
@@ -222,6 +234,9 @@
  <<"INSERT INTO cookbooks (authz_id, org_id, name) VALUES ($1, $2, $3)">>}.
 
 {delete_cookbook_by_orgid_name, <<"DELETE FROM cookbooks WHERE (org_id = $1 AND name = $2)">>}.
+
+{bulk_get_cookbook_authz_ids,
+ <<"SELECT id, authz_id FROM cookbooks WHERE id = ANY($1)">>}.
 
 %% cookbook version queries
 {find_cookbook_version_by_orgid_name_version,

--- a/apps/chef_db/src/chef_db.erl
+++ b/apps/chef_db/src/chef_db.erl
@@ -91,6 +91,7 @@
          update/3,
          fetch/2,
          bulk_get/4,
+         bulk_get_authz_ids/3,
          data_bag_exists/3,
          environment_exists/3]).
 
@@ -667,6 +668,12 @@ bulk_get(#context{reqid = ReqId}, OrgName, client, Ids) ->
 % TODO: Can this come out now?
 bulk_get(Ctx, OrgName, Type, Ids) ->
     bulk_get_couchdb(Ctx, OrgName, Type, Ids).
+
+-spec bulk_get_authz_ids(#context{}, chef_type(), [binary()]) ->
+                        [{binary(), binary()}] | {error, _}.
+%% @doc Return a list of authz IDs corresponding to the specified list of IDs
+bulk_get_authz_ids(#context{reqid = ReqId}, Type, Ids) ->
+    bulk_get_result(?SH_TIME(ReqId, chef_sql, bulk_get_authz_ids, (Type, Ids))).
 
 bulk_get_result({ok, not_found}) ->
     [];

--- a/apps/chef_db/src/chef_sql.erl
+++ b/apps/chef_db/src/chef_sql.erl
@@ -46,6 +46,8 @@
          fetch_object_names/1,
          fetch/1,
 
+         bulk_get_authz_ids/2,
+
          %% checksum ops
          mark_checksums_as_uploaded/2,
          non_uploaded_checksums/2,
@@ -82,6 +84,7 @@
 
          fetch_environment_filtered_recipes/2,
          fetch_latest_cookbook_versions/3,
+
 
          %% Sandbox Ops
          create_sandbox/1,
@@ -878,6 +881,23 @@ bulk_get_objects(Type, Ids) ->
         {error, Error} ->
             {error, Error}
     end.
+
+
+-spec bulk_get_authz_ids(chef_type(), [binary()]) ->
+                              {ok, [binary()] | not_found} |
+                              {error, term()}.
+%% @doc return a list of Authz IDs for the given IDs
+bulk_get_authz_ids(Type, Ids) ->
+    Query = list_to_existing_atom("bulk_get_" ++ atom_to_list(Type) ++ "_authz_ids"),
+    case sqerl:select(Query, [Ids], rows, []) of
+        {ok, none} ->
+            {ok, not_found};
+        {ok, L} when is_list(L) ->
+            {ok, L};
+        {error, Error} ->
+            {error, Error}
+    end.
+
 
 -spec create_object(Object :: chef_object() |
                               #chef_sandbox{} |

--- a/apps/oc_chef_authz/test/oc_chef_authz_tests.erl
+++ b/apps/oc_chef_authz/test/oc_chef_authz_tests.erl
@@ -254,7 +254,7 @@ bulk_actor_is_authorized_test_() ->
                                    {ok, "200", [], <<"{\"unauthorized\":[\"a\",\"b\"]}">>}
                            end),
                Resources = [{<<"a">>, a_data}, {<<"b">>, b_data}],
-               ?assertEqual({false,[b_data, a_data]},
+               ?assertEqual({false,{[b_data, a_data],[]}},
                             oc_chef_authz:bulk_actor_is_authorized(<<"test-req-id">>, <<"abcabc123">>, object,
                                                                    Resources, read))
        end},
@@ -268,7 +268,10 @@ bulk_actor_is_authorized_test_() ->
                                    {ok, "200", [], <<"{\"unauthorized\":[\"b\",\"l\",\"o\",\"t\"]}">>}
                            end),
                Resources = [ {I, binary_to_atom(<<I/binary, "_data">>, utf8)} || I <- Ids ],
-               ?assertEqual({false,[t_data, o_data, l_data, b_data]},
+               ?assertEqual({false,{[t_data, o_data, l_data, b_data],
+                                  [s_data, r_data, q_data, p_data, n_data, m_data,
+                                   k_data, j_data, i_data, h_data, g_data, f_data,
+                                   e_data, d_data, c_data, a_data]}},
                             oc_chef_authz:bulk_actor_is_authorized(<<"test-req-id">>,
                                                                    <<"abcabc123">>,
                                                                    object,

--- a/apps/oc_chef_wm/src/chef_wm_search.erl
+++ b/apps/oc_chef_wm/src/chef_wm_search.erl
@@ -166,7 +166,7 @@ filter_permitted_results(ReqId, RequestorId, OrgId, DbContext, {data_bag, BagNam
     case chef_db:fetch(#chef_data_bag{org_id = OrgId, name = BagName}, DbContext) of
         not_found -> [];
         #chef_data_bag{authz_id = AuthzId} ->
-            case ?SH_TIME(oc_chef_authz, is_authorized_on_resource, (RequestorId, object, AuthzId, actor, RequestorId, read)) of
+            case ?SH_TIME(ReqId, oc_chef_authz, is_authorized_on_resource, (RequestorId, object, AuthzId, actor, RequestorId, read)) of
                 false -> [];
                 true -> Ids;
                 Error ->
@@ -185,8 +185,8 @@ filter_permitted_results(ReqId, RequestorId, _OrgId, DbContext, IndexType, Ids) 
     case ?SH_TIME(ReqId, oc_chef_authz, bulk_actor_is_authorized, (ReqId, RequestorId, Type, AuthzIds, read)) of
         true ->
             Ids;
-        {false, NoAuthzList} ->
-            [ Id || Id <- Ids, not lists:member(Id, NoAuthzList)];
+        {false, {_NoAuthzList, AuthzList}} ->
+            AuthzList;
         {error, Why} ->
             lager:error("failed to check permissions due to ~p on ~p~n", [Why, AuthzIds])
     end.

--- a/apps/oc_chef_wm/src/chef_wm_search.erl
+++ b/apps/oc_chef_wm/src/chef_wm_search.erl
@@ -156,6 +156,39 @@ solr_ids_length({Solr1Ids, _}) ->
 solr_ids_length(Solr1Ids) ->
     length(Solr1Ids).
 
+%% @doc Check the READ authz permissions on a list of search results, returning only the
+%% list of available results
+filter_permitted_results(_ReqId, _RequestorId, _OrgId, _DbContext, _IndexType, []) ->
+    [];
+filter_permitted_results(ReqId, RequestorId, OrgId, DbContext, {data_bag, BagName}, Ids) ->
+    case chef_db:fetch(#chef_data_bag{org_id = OrgId, name = BagName}, DbContext) of
+        not_found -> [];
+        #chef_data_bag{authz_id = AuthzId} ->
+            case oc_chef_authz:is_authorized_on_resource(RequestorId, object, AuthzId, actor, RequestorId, read) of
+                false -> [];
+                true -> Ids;
+                Error ->
+                    lager:error("is_authorized_on_resource failed (~p, ~p, ~p): ~p~n",
+                                [read, {data_bag, BagName}, RequestorId, Error]),
+                    {{halt, 500}, ReqId}
+            end
+    end;
+filter_permitted_results(ReqId, RequestorId, _OrgId, DbContext, IndexType, Ids) ->
+    Auth = chef_db:bulk_get_authz_ids(DbContext, IndexType, Ids),
+    AuthzIds = [ {AuthzId, Id} || [Id, AuthzId] <- Auth ],
+    Type = case IndexType of
+               client -> actor;
+               _ -> object
+           end,
+    case ?SH_TIME(ReqId, oc_chef_authz, bulk_actor_is_authorized, (ReqId, RequestorId, Type, AuthzIds, read)) of
+        true ->
+            Ids;
+        {false, NoAuthzList} ->
+            [ Id || Id <- Ids, not lists:member(Id, NoAuthzList)];
+        {error, Why} ->
+            lager:error("failed to check permissions due to ~p on ~p~n", [Why, AuthzIds])
+    end.
+
 %% Return current app config value for batch size, defaulting if absent.
 batch_size() ->
     envy:get(oc_chef_wm, bulk_fetch_batch_size, ?DEFAULT_BATCH_SIZE, positive_integer).
@@ -232,10 +265,10 @@ make_bulk_get_fun(DbContext, OrgName, {data_bag, BagName}, [], _Req) ->
             %% add a special bulk get query that also returns bag_name and item_name
             %% and hand-craft the json to avoid parsing.
             [ begin
-                        RawItem = chef_json:decode(chef_db_compression:decompress(Item)),
-                        ItemName = ej:get({<<"id">>}, RawItem),
-                        chef_data_bag_item:wrap_item(BagName, ItemName, RawItem)
-                end || Item <- Items ]
+                  RawItem = chef_json:decode(chef_db_compression:decompress(Item)),
+                  ItemName = ej:get({<<"id">>}, RawItem),
+                  chef_data_bag_item:wrap_item(BagName, ItemName, RawItem)
+              end || Item <- Items ]
     end;
 make_bulk_get_fun(DbContext, OrgName, Type, [], _Req) ->
     %% all other types just call into chef_db

--- a/apps/oc_chef_wm/src/chef_wm_search.erl
+++ b/apps/oc_chef_wm/src/chef_wm_search.erl
@@ -121,7 +121,12 @@ to_json(Req, #base_state{chef_db_context = DbContext,
             IndexType = Query#chef_solr_query.index,
             Paths = SearchState#search_state.partial_paths,
             BulkGetFun = make_bulk_get_fun(DbContext, OrgName, IndexType, Paths, Req),
-            FilteredIds = filter_permitted_results(ReqId, RequestorId, OrgId, DbContext, IndexType, Ids),
+
+            FilteredIds = case envy:get(oc_chef_wm, strict_search_result_acls, false, boolean) of
+                             true ->
+                                 filter_permitted_results(ReqId, RequestorId, OrgId, DbContext, IndexType, Ids);
+                             false -> Ids
+                         end,
             {DbNumFound, Ans} = make_search_results(BulkGetFun, FilteredIds, BatchSize,
                                                     Start, SolrNumFound),
             State1 = State#base_state{log_msg = search_log_msg(SolrNumFound,

--- a/apps/oc_chef_wm/src/chef_wm_search.erl
+++ b/apps/oc_chef_wm/src/chef_wm_search.erl
@@ -112,7 +112,8 @@ to_json(Req, #base_state{chef_db_context = DbContext,
                          resource_state = SearchState,
                          organization_name = OrgName,
                          organization_guid = OrgId,
-                         reqid = ReqId} = State) ->
+                         reqid = ReqId,
+                         requestor_id = RequestorId} = State) ->
     BatchSize = batch_size(),
     Query = SearchState#search_state.solr_query,
     case solr_query(Query, ReqId) of
@@ -120,7 +121,8 @@ to_json(Req, #base_state{chef_db_context = DbContext,
             IndexType = Query#chef_solr_query.index,
             Paths = SearchState#search_state.partial_paths,
             BulkGetFun = make_bulk_get_fun(DbContext, OrgName, IndexType, Paths, Req),
-            {DbNumFound, Ans} = make_search_results(BulkGetFun, Ids, BatchSize,
+            FilteredIds = filter_permitted_results(ReqId, RequestorId, OrgId, DbContext, IndexType, Ids),
+            {DbNumFound, Ans} = make_search_results(BulkGetFun, FilteredIds, BatchSize,
                                                     Start, SolrNumFound),
             State1 = State#base_state{log_msg = search_log_msg(SolrNumFound,
                                                                solr_ids_length(Ids), DbNumFound)},
@@ -164,7 +166,7 @@ filter_permitted_results(ReqId, RequestorId, OrgId, DbContext, {data_bag, BagNam
     case chef_db:fetch(#chef_data_bag{org_id = OrgId, name = BagName}, DbContext) of
         not_found -> [];
         #chef_data_bag{authz_id = AuthzId} ->
-            case oc_chef_authz:is_authorized_on_resource(RequestorId, object, AuthzId, actor, RequestorId, read) of
+            case ?SH_TIME(oc_chef_authz, is_authorized_on_resource, (RequestorId, object, AuthzId, actor, RequestorId, read)) of
                 false -> [];
                 true -> Ids;
                 Error ->

--- a/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -517,7 +517,7 @@ check_cookbook_authz(Cookbooks, _Req, #base_state{reqid = ReqId,
             Report = {check_cookbook_authz, {Why, ReqId}},
             lager:error("~p", [Report]),
             error(Report);
-        {false, NoAuthzList} ->
+        {false, {NoAuthzList, _AuthzList}} ->
             {error, {[{<<"message">>, <<"Read permission is not granted for one or more cookbooks">>},
                       {<<"unauthorized_cookbooks">>, NoAuthzList}]}}
     end.


### PR DESCRIPTION
We now check ACLs before returning search results. In the data bag
case, we check the ACL on the data bag before returning data bag items,
otherwise we just check the ACLs on the objects directly.
 