### PR TITLE
move all key functions to chef_key_base [1/5]

### DIFF
--- a/apps/chef_objects/src/chef_key.erl
+++ b/apps/chef_objects/src/chef_key.erl
@@ -148,7 +148,7 @@ new_record(ApiVersion, _OrgId, _AuthzId, {Id, KeyData}) ->
               expires_at = Expires}.
 
 safe_key_version(PublicKey) ->
-    try chef_object_base:key_version(PublicKey) of
+    try chef_key_base:key_version(PublicKey) of
         Result -> Result
     catch
         _:_ -> throw(invalid_public_key)
@@ -195,7 +195,7 @@ validate_expiration_date(Required, EJ) ->
   end.
 
 name_and_public_key_validation_spec(Req) ->
-  {[ chef_object_base:public_key_spec(Req),
+  {[ chef_key_base:public_key_spec(Req),
      {{Req, <<"name">>}, {string_match, chef_regex:regex_for(key_name)}} ]}.
 
 update_query(_ObjectRec) ->

--- a/apps/chef_objects/src/chef_key_base.erl
+++ b/apps/chef_objects/src/chef_key_base.erl
@@ -1,0 +1,166 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 80 -*-
+%% ex: ts=4 sw=4 et
+%% @author Marc Paradise <marc@chef.io>
+%%
+%% Copyright 2015 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_key_base).
+
+-include("../../include/chef_types.hrl").
+
+-export([maybe_generate_key_pair/1,
+         set_key_pair/3,
+         set_public_key/2,
+         valid_public_key/1,
+         public_key_spec/1,
+         cert_or_key/1,
+         extract_public_key/1,
+         key_version/1]).
+
+%% @doc Conditionally generate and add key pair data.
+%%
+%% If the request data contains "private_key":true, then we will generate a new key pair. In
+%% this case, we'll add the new public and private keys into the EJSON since
+%% update_from_json will use it to set the response.
+-spec maybe_generate_key_pair(ej:json_object()) -> ej:json_object() | keygen_timeout.
+maybe_generate_key_pair(Data) ->
+    case ej:get({<<"private_key">>}, Data) of
+        true ->
+            case chef_keygen_cache:get_key_pair() of
+                {PublicKey, PrivateKey} ->
+                    set_key_pair(Data, {public_key, PublicKey}, {private_key, PrivateKey});
+                keygen_timeout ->
+                    keygen_timeout
+            end;
+        _ ->
+            Data
+    end.
+
+
+%% @doc Add public and private key data to `EJ'. This function infers
+%% the key type and puts the public key data in either a `certificate' or
+%% `public_key' field.
+%% If a private key is defined, then the private key will be placed in the `private_key'
+%% field.
+-spec set_key_pair(ej:json_object(), {public_key, undefined | null| binary()}, {private_key, undefined | binary()}) -> ej:json_object().
+set_key_pair(EJ, {public_key, PublicKey}, {private_key, PrivateKey}) ->
+    EJ1 = set_public_key(EJ, PublicKey),
+    case PrivateKey of
+        undefined ->
+            EJ1;
+        _ ->
+            ej:set({<<"private_key">>}, EJ1, PrivateKey)
+    end.
+
+
+
+%% @doc Sets either the `certificate' or `public_key' field of
+%% `EJ' depending on the value of `PublicKey'.
+-spec set_public_key(ej:json_object(), null | undefined | binary()) -> ej:json_object().
+set_public_key(EJ, null) ->
+    ej:set({<<"public_key">>}, EJ, null);
+set_public_key(EJ, PublicKey) ->
+   case key_version(PublicKey) of
+        ?KEY_VERSION ->
+          EJ1 = ej:set({<<"public_key">>}, EJ, PublicKey),
+          ej:delete({<<"certificate">>}, EJ1);
+        ?CERT_VERSION ->
+          EJ1 = ej:set({<<"certificate">>}, EJ, PublicKey),
+          ej:delete({<<"public_key">>}, EJ1)
+    end.
+
+
+%% Determine the "pubkey_version" of a key or certificate in PEM
+%% format. Certificates are version 1. Public keys in either PKCS1 or
+%% SPKI format are version 0. The PKCS1 format is deprecated, but
+%% supported for read. We will only generate certs or SPKI packaged
+%% keys.
+-spec key_version(<<_:64,_:_*8>>) -> 0 | 1.
+key_version(null) ->
+    null;
+key_version(<<"-----BEGIN CERTIFICATE", _Bin/binary>>) ->
+    %% cert
+    ?CERT_VERSION;
+key_version(<<"-----BEGIN PUBLIC KEY", _Bin/binary>>) ->
+    %% SPKI
+    ?KEY_VERSION;
+key_version(<<"-----BEGIN RSA PUBLIC KEY", _Bin/binary>>) ->
+    %% PKCS1
+    ?KEY_VERSION.
+
+-spec valid_public_key(<<_:64, _:_*8>>) -> ok | error.
+valid_public_key(PublicKey) ->
+    case has_public_key_header(PublicKey) of
+        true ->
+            case chef_authn:extract_public_key(PublicKey) of
+                {error, bad_key} ->
+                    error;
+                _ ->
+                    ok
+            end;
+        false ->
+            error
+    end.
+
+-spec has_public_key_header(binary()) -> true | false.
+has_public_key_header(<<"-----BEGIN PUBLIC KEY", _/binary>>) ->
+    true;
+has_public_key_header(<<"-----BEGIN RSA PUBLIC KEY", _/binary>>) ->
+    true;
+has_public_key_header(_) ->
+    false.
+
+-spec public_key_spec( req | opt ) -> term().
+public_key_spec(OptOrRequired) ->
+    {{OptOrRequired,<<"public_key">>}, {fun_match, {fun valid_public_key/1, string,
+                                            <<"Public Key must be a valid key.">>}}}.
+
+cert_or_key(Payload) ->
+    %% Some consumers of the API, such as webui, will generate a
+    %% JSON { public_key: null } to mean, "do not change it". By
+    %% default, null is treated as a defined, and will erase the
+    %% public_key in the database. We use value_or_undefined() to
+    %% convert all null into undefined.
+    Cert = value_or_undefined({<<"certificate">>}, Payload),
+    PublicKey = value_or_undefined({<<"public_key">>}, Payload),
+    %% Take certificate first, then public_key
+    case Cert of
+        undefined ->
+            {PublicKey, ?KEY_VERSION};
+        _ ->
+            {Cert, ?CERT_VERSION}
+    end.
+
+extract_public_key(null) -> null;
+extract_public_key(<<"null">>) -> null;
+extract_public_key(Data) ->
+    case key_version(Data) of
+        ?KEY_VERSION ->
+            Data;
+        ?CERT_VERSION ->
+            chef_authn:extract_pem_encoded_public_key(Data)
+    end.
+
+value_or_undefined(Key, Data) ->
+  case ej:get(Key, Data) of
+    null ->
+      undefined;
+    Value ->
+      Value
+  end.
+

--- a/apps/chef_objects/src/chef_user.erl
+++ b/apps/chef_objects/src/chef_user.erl
@@ -126,7 +126,7 @@ new_record(ApiVersion, OrgId, AuthzId, Data) ->
     Email = value_or_null({<<"email">>}, UserData),
     ExtAuthUid = value_or_null({<<"external_authentication_uid">>}, UserData),
     EnableRecovery = ej:get({<<"recovery_authentication_enabled">>}, UserData) =:= true,
-    {PublicKey, PubkeyVersion} = chef_object_base:cert_or_key(UserData),
+    {PublicKey, PubkeyVersion} = chef_key_base:cert_or_key(UserData),
     SerializedObject = { whitelisted_values(UserData, ?JSON_SERIALIZABLE) },
     #chef_user{server_api_version = ApiVersion,
                id = Id,
@@ -242,7 +242,7 @@ assemble_user_ejson(#chef_user{username = Name,
     % public_key can mean either public key or cert.
     % if it's a cert, we need to extract the public key -
     % we don't want to hand the cert back on user GET.
-    RealPubKey = chef_object_base:extract_public_key(KeyOrCert),
+    RealPubKey = chef_key_base:extract_public_key(KeyOrCert),
     % Where external auth is enable, email may be null/undefined
     Email2 = case Email of
         undefined -> <<"">>;
@@ -267,12 +267,12 @@ parse_binary_json(Bin) ->
 
 -spec parse_binary_json(binary(), create | update, #chef_user{} | undefined) -> {ok, ej:json_object()}. % or throw
 parse_binary_json(Bin, Operation, User) ->
-    EJ = chef_object_base:delete_null_public_key(chef_json:decode(Bin)),
+    EJ = delete_null_public_key(chef_json:decode(Bin)),
     EJson = case ej:get({<<"private_key">>}, EJ) of
         true ->
             ej:delete({<<"public_key">>}, EJ);
         _ ->
-            validate_user(EJ, {[ chef_object_base:public_key_spec(opt) ]}),
+            validate_user(EJ, {[ chef_key_base:public_key_spec(opt) ]}),
             EJ
     end,
 
@@ -305,6 +305,16 @@ external_auth_uid(EJson, _) ->
 
 undefined_or_value(null) -> undefined;
 undefined_or_value(Value) -> Value.
+
+%% Hack to get null public_key accepted as undefined
+-spec delete_null_public_key(ej:json_object()) -> ej:json_object().
+delete_null_public_key(Ejson) ->
+    case ej:get({<<"public_key">>}, Ejson) of
+        null ->
+            ej:delete({<<"public_key">>}, Ejson);
+        _ ->
+            Ejson
+    end.
 
 %%-spec validate_user(ejson_term(), ejson_term()) -> {ok, ejson_term()}. % or throw
 validate_user(User, Spec) ->
@@ -360,7 +370,7 @@ update_from_ejson(#chef_user{} = User, UserEJson) ->
     RecoveryAuthenticationEnabled = value_or_existing({<<"recovery_authentication_enabled">>},
                                                       UserEJson,
                                                       User#chef_user.recovery_authentication_enabled) =:= true,
-    {Key, Version} = chef_object_base:cert_or_key(UserEJson),
+    {Key, Version} = chef_key_base:cert_or_key(UserEJson),
 
     User2 = case Key of
         undefined ->
@@ -469,3 +479,4 @@ list(#chef_user{email = EMail}, CallbackFun) ->
 
 set_api_version(ObjectRec, Version) ->
     ObjectRec#chef_user{server_api_version = Version}.
+

--- a/apps/chef_objects/test/chef_client_tests.erl
+++ b/apps/chef_objects/test/chef_client_tests.erl
@@ -50,7 +50,8 @@ cert_data() ->
 assemble_client_ejson_test_() ->
     [{"obtain expected EJSON",
       fun() ->
-              Client = #chef_client{name = <<"alice">>,
+              Client = #chef_client{server_api_version = ?API_MIN_VER,
+                                    name = <<"alice">>,
                                     admin = true,
                                     validator = false,
                                     public_key = public_key_data()},
@@ -68,7 +69,8 @@ assemble_client_ejson_test_() ->
       end},
      {"converts certificate to public key",
       fun() ->
-              Client = #chef_client{name = <<"alice">>,
+              Client = #chef_client{server_api_version = ?API_MIN_VER,
+                                    name = <<"alice">>,
                                     admin = true,
                                     validator = false,
                                     public_key = cert_data()},
@@ -92,13 +94,13 @@ parse_binary_json_test_() ->
     [{"Error thrown on mismatched names",
       fun() ->
           Body = <<"{\"name\":\"name\",\"clientname\":\"notname\"}">>,
-          ?assertThrow({client_name_mismatch}, chef_client:parse_binary_json(Body, <<"name">>))
+          ?assertThrow({client_name_mismatch}, chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>))
       end
      },
      {"Can create with only name",
       fun() ->
           Body = <<"{\"name\":\"name\"}">>,
-          {ok, Client} = chef_client:parse_binary_json(Body, <<"name">>),
+          {ok, Client} = chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>),
           Name = ej:get({<<"name">>}, Client),
           ClientName = ej:get({<<"clientname">>}, Client),
           ?assertEqual(Name, ClientName)
@@ -107,7 +109,7 @@ parse_binary_json_test_() ->
      {"Can create with only clientname",
       fun() ->
           Body = <<"{\"clientname\":\"name\"}">>,
-          {ok, Client} = chef_client:parse_binary_json(Body, <<"name">>),
+          {ok, Client} = chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>),
           Name = ej:get({<<"name">>}, Client),
           ClientName = ej:get({<<"clientname">>}, Client),
           ?assertEqual(Name, ClientName)
@@ -117,7 +119,7 @@ parse_binary_json_test_() ->
       fun() ->
           Body = <<"{\"validator\":false}">>,
           ?assertThrow({both_missing, <<"name">>, <<"clientname">>},
-                       chef_client:parse_binary_json(Body, undefined))
+                       chef_client:parse_binary_json(?API_MIN_VER, Body, undefined))
       end
      },
      {"Error thrown with bad name",
@@ -125,7 +127,7 @@ parse_binary_json_test_() ->
           Body = <<"{\"name\":\"bad~name\"}">>,
           ?assertThrow({bad_client_name, <<"bad~name">>,
                         <<"Malformed client name.  Must be A-Z, a-z, 0-9, _, -, or .">>},
-                       chef_client:parse_binary_json(Body, <<"bad~name">>))
+                       chef_client:parse_binary_json(?API_MIN_VER, Body, <<"bad~name">>))
       end
      }
     ].

--- a/apps/chef_objects/test/chef_key_base_tests.erl
+++ b/apps/chef_objects/test/chef_key_base_tests.erl
@@ -1,0 +1,59 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%%
+%% @author Marc Paradise <marc@chef.io>
+%%
+%% Copyright 2015 Chef Software, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_key_base_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("../../include/chef_types.hrl").
+
+public_key_data() ->
+    {ok, Bin} = file:read_file("../test/spki_public.pem"),
+    Bin.
+
+cert_data() ->
+    {ok, Bin} = file:read_file("../test/cert.pem"),
+    Bin.
+
+set_key_pair_test_() ->
+    Ejson = {[]},
+    PrivateKey = <<"private">>,
+    DataForType = fun(key) -> public_key_data();
+                     (cert) -> cert_data()
+                  end,
+    KeyForType = fun(key) -> <<"public_key">>;
+                    (cert) -> <<"certificate">>
+                 end,
+    NotKeyForType = fun(key) -> <<"certificate">>;
+                       (cert) -> <<"public_key">>
+                    end,
+    Tests = [
+             begin
+                 Got = chef_key_base:set_key_pair(Ejson,
+                                                  {public_key, DataForType(Type)},
+                                                  {private_key, PrivateKey}),
+                 [?_assertEqual(PrivateKey, ej:get({<<"private_key">>}, Got)),
+                  ?_assertEqual(DataForType(Type), ej:get({KeyForType(Type)}, Got)),
+                  ?_assertEqual(undefined, ej:get({NotKeyForType(Type)}, Got))]
+             end
+             || Type <- [key, cert] ],
+    lists:flatten(Tests).
+

--- a/apps/chef_objects/test/chef_object_base_tests.erl
+++ b/apps/chef_objects/test/chef_object_base_tests.erl
@@ -167,44 +167,6 @@ semantic_duplication_test_() ->
       end}
     ].
 
-public_key_data() ->
-    {ok, Bin} = file:read_file("../test/spki_public.pem"),
-    Bin.
-
-cert_data() ->
-    {ok, Bin} = file:read_file("../test/cert.pem"),
-    Bin.
-
-set_key_pair_test_() ->
-    Ejson = {[]},
-    PrivateKey = <<"private">>,
-    DataForType = fun(key) ->
-                          public_key_data();
-                     (cert) ->
-                          cert_data()
-                  end,
-    KeyForType = fun(key) ->
-                         <<"public_key">>;
-                    (cert) ->
-                         <<"certificate">>
-                 end,
-    NotKeyForType = fun(key) ->
-                            <<"certificate">>;
-                       (cert) ->
-                            <<"public_key">>
-                    end,
-    Tests = [
-             begin
-                 Got = chef_object_base:set_key_pair(Ejson,
-                                                {public_key, DataForType(Type)},
-                                                {private_key, PrivateKey}),
-                 [?_assertEqual(PrivateKey, ej:get({<<"private_key">>}, Got)),
-                  ?_assertEqual(DataForType(Type), ej:get({KeyForType(Type)}, Got)),
-                  ?_assertEqual(undefined, ej:get({NotKeyForType(Type)}, Got))]
-             end
-             || Type <- [key, cert] ],
-    lists:flatten(Tests).
-
 parse_date_test() ->
     ?assertEqual(?INFINITY_TIMESTAMP, chef_object_base:parse_date(<<"infinity">>)).
 

--- a/apps/oc_chef_wm/src/chef_wm_clients.erl
+++ b/apps/oc_chef_wm/src/chef_wm_clients.erl
@@ -107,7 +107,7 @@ create_path(Req, #base_state{resource_state = #client_state{client_data = Client
 %% and return the private key as part of the response
 from_json(Req, #base_state{resource_state =
                                #client_state{client_data = ClientData}} = State) ->
-    KeyData = case chef_object_base:cert_or_key(ClientData) of
+    KeyData = case chef_key_base:cert_or_key(ClientData) of
                   {undefined, _} ->
                       chef_keygen_cache:get_key_pair();
                   {PubKey, _PubKeyVersion} ->
@@ -121,7 +121,7 @@ handle_client_create({PublicKey, PrivateKey}, Req,
                      #base_state{resource_state =
                                      #client_state{client_data = ClientData,
                                                    client_authz_id = AuthzId}} = State) ->
-    ClientData1 = chef_object_base:set_public_key(ClientData, PublicKey),
+    ClientData1 = chef_key_base:set_public_key(ClientData, PublicKey),
     case oc_chef_wm_base:create_from_json(Req, State, chef_client, {authz_id, AuthzId}, ClientData1) of
         {true, Req1, State1} ->
             %% create_from_json by default sets the response to a json body
@@ -129,7 +129,7 @@ handle_client_create({PublicKey, PrivateKey}, Req,
             %% pair so we replace the response.
             Name = ej:get({<<"name">>}, ClientData),
             URI = oc_chef_wm_routes:route(client, Req1, [{name, Name}]),
-            EJSON = chef_object_base:set_key_pair({[{<<"uri">>, URI}]},
+            EJSON = chef_key_base:set_key_pair({[{<<"uri">>, URI}]},
                                                   {public_key, PublicKey},
                                                   {private_key, PrivateKey}),
             {true, chef_wm_util:set_json_body(Req1, EJSON), State1};

--- a/apps/oc_chef_wm/src/chef_wm_named_client.erl
+++ b/apps/oc_chef_wm/src/chef_wm_named_client.erl
@@ -116,7 +116,7 @@ auth_info(Req, #base_state{resource_state =
 from_json(Req, #base_state{resource_state =
                                #client_state{chef_client = Client,
                                              client_data = ClientData}} = State) ->
-    case chef_wm_util:maybe_generate_key_pair(ClientData) of
+    case chef_key_base:maybe_generate_key_pair(ClientData) of
         keygen_timeout ->
             {{halt, 503}, Req, State#base_state{log_msg = keygen_timeout}};
         ClientData1 ->

--- a/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -30,15 +30,13 @@
          get_header_fun/2,
          fetch_org_metadata/1,
          base_mods/0,
-         maybe_generate_key_pair/1,
          not_found_message/2,
          num_versions/1,
          num_versions/2,
          object_name/2,
          set_json_body/2,
          set_uri_of_created_resource/2,
-         with_error_body/2,
-         lists_diff/2
+         with_error_body/2
         ]).
 
 -include("../../include/oc_chef_wm.hrl").
@@ -314,33 +312,4 @@ port_string(Default) when Default =:= 80; Default =:= 443 ->
     "";
 port_string(Port) ->
     [$:|erlang:integer_to_list(Port)].
-
-%% @doc Conditionally generate and add key pair data.
-%%
-%% If the request data contains "private_key":true, then we will generate a new key pair. In
-%% this case, we'll add the new public and private keys into the EJSON since
-%% update_from_json will use it to set the response.
-maybe_generate_key_pair(Data) ->
-    case ej:get({<<"private_key">>}, Data) of
-        true ->
-            case chef_keygen_cache:get_key_pair() of
-                {PublicKey, PrivateKey} ->
-                    chef_object_base:set_key_pair(Data,
-                                                  {public_key, PublicKey},
-                                                  {private_key, PrivateKey});
-                keygen_timeout ->
-                    keygen_timeout
-            end;
-        _ ->
-            Data
-    end.
-
--spec lists_diff(list(), list()) -> {list(), list()}.
-lists_diff(FirstList, SecondList) ->
-    lists_diff_sorted(lists:sort(FirstList), lists:sort(SecondList)).
-lists_diff_sorted(FirstList, SecondList) ->
-    FirstSet = sets:from_list(FirstList),
-    SecondSet = sets:from_list(SecondList),
-    {lists:sort(sets:to_list(sets:subtract(FirstSet, SecondSet))),
-     lists:sort(sets:to_list(sets:subtract(SecondSet, FirstSet)))}.
 

--- a/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
@@ -179,7 +179,7 @@ from_json(Req, #base_state{resource_args = invitation_response,
             end
     end;
 from_json(Req, #base_state{resource_state = #user_state{ chef_user = User, user_data = UserData}} = State) ->
-    case chef_wm_util:maybe_generate_key_pair(UserData) of
+    case chef_key_base:maybe_generate_key_pair(UserData) of
         keygen_timeout ->
             {{halt, 503}, Req, State#base_state{log_msg = keygen_timeout}};
         UserDataWithKeys ->

--- a/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
@@ -196,9 +196,8 @@ maybe_create_client({PublicKey, PrivateKey}, Req,
                                                                      name = OrgName
                                                                     }} = ResourceState} = State) ->
     ClientName = <<OrgName/binary,"-validator">>,
-    ClientEJson = chef_object_base:set_public_key({[{<<"name">>, ClientName},
-                                                    {<<"validator">>, true}]},
-                                                  PublicKey),
+    ClientEJson = chef_key_base:set_public_key({[{<<"name">>, ClientName},
+                                                 {<<"validator">>, true}]}, PublicKey),
 
     %% Update the return state
     OrgEJson =  {[{<<"uri">>, oc_chef_wm_routes:route(organization, Req, [{name, OrgName}])},

--- a/apps/oc_chef_wm/src/oc_chef_wm_users.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_users.erl
@@ -79,7 +79,7 @@ create_path(Req, #base_state{resource_state = #user_state{user_data = UserData}}
   {binary_to_list(Name), Req, State}.
 
 from_json(Req, #base_state{resource_state = #user_state{user_data = UserData}} = State) ->
-    KeyData = case chef_object_base:cert_or_key(UserData) of
+    KeyData = case chef_key_base:cert_or_key(UserData) of
                   {undefined, _} ->
                       chef_keygen_cache:get_key_pair();
                   {PubKey, _PubKeyVersion} ->
@@ -90,11 +90,10 @@ from_json(Req, #base_state{resource_state = #user_state{user_data = UserData}} =
 handle_user_create(keygen_timeout, Req, State) ->
     {{halt, 503}, Req, State#base_state{log_msg = keygen_timeout}};
 handle_user_create({PublicKey, PrivateKey}, Req,
-                   #base_state{resource_state =
-                                   #user_state{user_data = UserData,
-                                               user_authz_id = AuthzId}} = State) ->
+                   #base_state{resource_state = #user_state{user_data = UserData,
+                                                            user_authz_id = AuthzId}} = State) ->
     Name = chef_user:username_from_ejson(UserData),
-    UserWithKey = chef_object_base:set_public_key(UserData, PublicKey),
+    UserWithKey = chef_key_base:set_public_key(UserData, PublicKey),
 
     case oc_chef_wm_base:create_from_json(Req, State, chef_user, {authz_id, AuthzId}, UserWithKey) of
         {true, Req1, State1} ->

--- a/apps/oc_chef_wm/test/chef_wm_util_tests.erl
+++ b/apps/oc_chef_wm/test/chef_wm_util_tests.erl
@@ -1,6 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%%
+%% Copyright 2013-2015 Chef Software, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -89,19 +90,3 @@ base_uri_test_() ->
     ].
 
 
-lists_diff_test_() ->
-    [
-     {"When lists equal returns {[],[]}",
-      ?_assertEqual({[],[]}, chef_wm_util:lists_diff(lists:seq(0,10),lists:seq(0,10)))},
-     {"When lists equal different order returns {[],[]}",
-      ?_assertEqual({[],[]}, chef_wm_util:lists_diff(lists:seq(0,10),lists:reverse(lists:seq(0,10))))},
-     {"When first list longer than second returns diff, []",
-      ?_assertEqual({lists:seq(0,5), []}, chef_wm_util:lists_diff(lists:seq(0,10), lists:seq(6,10)))},
-     {"When second list longer than first returns [], diff",
-      ?_assertEqual({[], lists:seq(0,5)}, chef_wm_util:lists_diff(lists:seq(6,10), lists:seq(0,10)))},
-     {"When differences in middle, returns diff, diff",
-      ?_assertEqual({[1,3,5,7,8,9,10], [2,4,6,11,12,13]}, chef_wm_util:lists_diff([1,3,5,7,8,9,10], [2,4,6,11,12,13]))},
-     {"When differences and different order, returns diff, diff",
-      ?_assertEqual({[1,3,5,7,8,9], [2,4,6,11,12,13]}, chef_wm_util:lists_diff([1,3,5,7,8,9,10], lists:reverse([10,2,4,6,11,12,13])))}
-
-    ].


### PR DESCRIPTION
This change consolidates key-related functions into new module chef_key_base 

PR 1 of 5, for v1 API changs to clients and users.  I have split them out for readability since after a fair chunk of rebasing. Each builds to an extent on the prior changes, but each change otherwise stands on its own.  The intent is to merge them  at the same time. 

