### PR TITLE
add wm_base callback to allow resource mods to modify body [2/5]

### DIFF
--- a/apps/oc_chef_wm/src/chef_wm_named_data.erl
+++ b/apps/oc_chef_wm/src/chef_wm_named_data.erl
@@ -2,6 +2,23 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author Christopher Maier <cm@chef.io>
+%%
+%% Copyright 2012-2015 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
 %% @doc Resource for /data/:BAG_NAME
 %%
 %% This resource module serves two purposes. We initially factored it into two separate
@@ -20,22 +37,6 @@
 %%
 %%
 %% @end
-%% Copyright 2012-2014 Chef Software, Inc. All Rights Reserved.
-%%
-%% This file is provided to you under the Apache License,
-%% Version 2.0 (the "License"); you may not use this file
-%% except in compliance with the License.  You may obtain
-%% a copy of the License at
-%%
-%%   http://www.apache.org/licenses/LICENSE-2.0
-%%
-%% Unless required by applicable law or agreed to in writing,
-%% software distributed under the License is distributed on an
-%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-%% KIND, either express or implied.  See the License for the
-%% specific language governing permissions and limitations
-%% under the License.
-%%
 
 
 -module(chef_wm_named_data).
@@ -61,8 +62,8 @@
          malformed_request_message/3,
          request_type/0,
          validate_request/3,
-         conflict_message/1
-        ]).
+         conflict_message/1,
+         finalize_create_body/3 ]).
 
 -export([
          allowed_methods/2,
@@ -132,26 +133,23 @@ create_path(Req, #base_state{resource_state = #data_state{
                                data_bag_item_name = ItemName}}=State) ->
     {binary_to_list(ItemName), Req, State}.
 
-from_json(Req, #base_state{
-                           resource_state = #data_state{data_bag_name = DataBagName,
-                                                        data_bag_item_ejson = ItemData}
-                          } = State) ->
-    case oc_chef_wm_base:create_from_json(Req, State, chef_data_bag_item, {authz_id,undefined}, {DataBagName, ItemData}) of
-        {true, _, NewState} ->
-            %% The Ruby API returns created items as-is, but with added chef_type and
-            %% data_bag fields. If those fields are present in the request, they are put
-            %% into the raw item data, but the values are overwritten for the return. When
-            %% this feature is enabled, erchef will mimic the Ruby API and force-add the
-            %% chef_type and data_bag keys to the item data. Current clients appear to rely
-            %% on this value, but it would be good to disable this and make the API more
-            %% sane. It is very confusing that you can specify bogus values, that look like
-            %% they are ignored, but actually end up in the item data.
-            ItemDataWithCruft = chef_data_bag_item:add_type_and_bag(DataBagName, ItemData),
-            Req1 = chef_wm_util:set_json_body(Req, ItemDataWithCruft),
-            {true, Req1, NewState};
-        AnyOtherCase ->
-            AnyOtherCase
-    end.
+from_json(Req, #base_state{resource_state = #data_state{data_bag_name = DataBagName,
+                                                        data_bag_item_ejson = ItemData} } = State) ->
+    oc_chef_wm_base:create_from_json(Req, State, chef_data_bag_item,
+                                     {authz_id,undefined}, {DataBagName, ItemData}).
+
+% Callback from create_from_json, which allows us to customize our body response.
+finalize_create_body(_Req, #base_state{ resource_state = #data_state{data_bag_name = DataBagName,
+                                                                     data_bag_item_ejson = ItemData} }, _BodyEJ ) ->
+    %% The Ruby API returns created items as-is, but with added chef_type and
+    %% data_bag fields. If those fields are present in the request, they are put
+    %% into the raw item data, but the values are overwritten for the return. When
+    %% this feature is enabled, erchef will mimic the Ruby API and force-add the
+    %% chef_type and data_bag keys to the item data. Current clients appear to rely
+    %% on this value, but it would be good to disable this and make the API more
+    %% sane. It is very confusing that you can specify bogus values, that look like
+    %% they are ignored, but actually end up in the item data.
+    chef_data_bag_item:add_type_and_bag(DataBagName, ItemData).
 
 to_json(Req, State) ->
     {items_for_data_bag(Req, State), Req, State}.

--- a/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -36,6 +36,7 @@
          object_name/2,
          set_json_body/2,
          set_uri_of_created_resource/2,
+         set_location_of_created_resource/2,
          with_error_body/2
         ]).
 
@@ -196,7 +197,12 @@ set_uri_of_created_resource(Uri, Req) when is_list(Uri) ->
 set_uri_of_created_resource(Uri, Req0) when is_binary(Uri) ->
     %% Uri needs to be a binary for encoding to JSON, but a string for the header value
     Req = set_json_body(Req0, {[{<<"uri">>, Uri}]}),
-    wrq:set_resp_header("Location", binary_to_list(Uri), Req).
+    set_location_of_created_resource(Uri, Req).
+
+set_location_of_created_resource(Uri, Req0) when is_list(Uri) ->
+    set_location_of_created_resource(list_to_binary(Uri), Req0);
+set_location_of_created_resource(Uri, Req0) when is_binary(Uri) ->
+    wrq:set_resp_header("Location", binary_to_list(Uri), Req0).
 
 %% @doc Extracts the name of a given object from the request path.  This is for use in
 %% resources that manipulate individual Chef objects, like nodes or roles.

--- a/include/oc_chef_wm.hrl
+++ b/include/oc_chef_wm.hrl
@@ -180,6 +180,7 @@
 -record(client_state, {
           client_data,
           client_authz_id,
+          keydata,
           chef_client :: #chef_client{} | not_found
          }).
 
@@ -278,6 +279,7 @@
 -record(user_state, {
           user_data,
           user_authz_id,
+          keydata,
           chef_user :: #chef_user{}
       }).
 


### PR DESCRIPTION
instead, implemented a create/update body callback that allows
resources to customize the body response when the default
oc_chef_wm_base:create_from_json/update_from_json functions are used
to handle the details of create/update.

Updated user, client, data bag, data bag item to use these callbacks
where possible.

---- 
PR 2 of 5, for v1 API changes to clients and users. I have split them out for readability since after a fair chunk of rebasing. Each builds to an extent on the prior changes, but each change otherwise stands on its own. The intent is to merge them at the same time. 