### PR TITLE
Add support for server-side key generation to keys REST API [PR 2/8]

### DIFF
--- a/apps/chef_test/src/chef_test_suite_helper.erl
+++ b/apps/chef_test/src/chef_test_suite_helper.erl
@@ -49,7 +49,9 @@
          list_records/1,
          update_record/1,
          fetch_record/1,
-         delete_record/1
+         delete_record/1,
+
+         value_matches_regex/2
         ]).
 
 -define(ORG_AUTHZ_ID, <<"10000000000000000000000000000002">>).
@@ -223,4 +225,15 @@ delete_record(Record0) ->
 list_records(Record0) ->
     Record = chef_object:set_api_version(Record0, ?API_MIN_VER),
     chef_sql:fetch_object_names(Record).
+
+value_matches_regex(undefined , _RE) ->
+    false;
+value_matches_regex(Value, RE) when is_list(RE) ->
+    {ok, RealRE} = re:compile(RE),
+    value_matches_regex(Value, RealRE);
+value_matches_regex(Value, RE) ->
+    case re:run(Value, RE) of
+        {match, _} -> true;
+        _ -> false
+    end.
 

--- a/apps/oc_chef_wm/src/chef_wm_malformed.erl
+++ b/apps/oc_chef_wm/src/chef_wm_malformed.erl
@@ -103,6 +103,11 @@ malformed_request_message(invalid_num_versions, _Req, _State) ->
 malformed_request_message({invalid_key, Key}, _Req, _State) ->
     error_envelope([<<"Invalid key ">>, Key, <<" in request body">>]);
 
+
+malformed_request_message(create_or_pubkey_missing, _Req, _State) ->
+    error_envelope([<<"You must either provide a valid value for 'public_key', or specify 'create_key': true">>]);
+malformed_request_message(create_and_pubkey_specified, _Req, _State) ->
+    error_envelope([<<"You must specify either create_key or public_key, but not both">>]);
 malformed_request_message(invalid_json_object, _Req, _State) ->
     error_envelope([<<"Incorrect JSON type for request body">>]);
 

--- a/include/oc_chef_wm.hrl
+++ b/include/oc_chef_wm.hrl
@@ -336,6 +336,7 @@
           parent_authz_id,
           parent_name,
           key_data,
+          generated_private_key,
           chef_key :: #chef_key{}
          }).
 


### PR DESCRIPTION
Added support to the keys endpoints for server-side generation of a new
client key  Validates to ensure that either public_key or
create_key is provided, and will fail with a 400 if both are provided.

If a key is generated (PUT or POST body contains "create_key":true)
it will be returned as "private_key": "$KEY" in the response JSON. If it
is not requested, a valid public key must be sent and the private_key
field will not be sent in the response body.

This is implemented under API v0, since it was an additive change.
----- 
2/ 8 I've split these into separate PRs to make the changes clearer, but am currently planning to merge all 8 down into master as a unit. 

/ping @chef/lob