### PR TITLE
Add v1+ api behaviors to chef_client [5/8]

### DIFF
--- a/apps/chef_db/priv/pgsql_statements.config
+++ b/apps/chef_db/priv/pgsql_statements.config
@@ -19,8 +19,6 @@
 
 {ping, <<"SELECT 'pong' as ping LIMIT 1">>}.
 
-%% chef user queries
-%% open source users have all the data of a private chef user + the admin field
 %% Query to count the number of nodes for license checks
 {count_nodes, <<"SELECT COUNT(*) as count FROM nodes">>}.
 
@@ -182,7 +180,9 @@
 
 %% client queries
 
-{find_client_by_orgid_name,
+
+% DEPRECATED as of APIv1
+{find_client_by_orgid_name_v0,
  <<"SELECT c.id, authz_id, org_id, name, validator, admin, k.public_key, k.key_version pubkey_version,
            c.last_updated_by, c.created_at, c.updated_at
       FROM clients c
@@ -190,15 +190,31 @@
      WHERE org_id = $1 AND name = $2
      LIMIT 1">>}.
 
-{insert_client,
+{find_client_by_orgid_name,
+ <<"SELECT c.id, authz_id, org_id, name, validator, c.last_updated_by, c.created_at, c.updated_at
+      FROM clients c
+     WHERE org_id = $1 AND name = $2
+     LIMIT 1">>}.
+
+% DEPRECATED as of APIv1
+{insert_client_v0,
  <<"INSERT INTO clients ( id, authz_id, org_id, name, validator, admin, public_key,"
    "    pubkey_version, last_updated_by, created_at, updated_at )"
    "  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)">>}.
 
+{insert_client,
+ <<"INSERT INTO clients ( id, authz_id, org_id, name, validator, last_updated_by, created_at, updated_at )"
+   "  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)">>}.
+
+% DEPRECATED as of APIv1
+{update_client_by_id_v0,
+ <<"UPDATE clients SET last_updated_by = $1, updated_at = $2, "
+   "       name = $3, public_key = $4, pubkey_version = $5, "
+   "       validator = $6, admin = $7  WHERE id = $8">>}.
+
 {update_client_by_id,
  <<"UPDATE clients SET last_updated_by = $1, updated_at = $2, "
-   "name = $3, public_key = $4, pubkey_version = $5, "
-   "validator = $6, admin = $7  WHERE id = $8">>}.
+   "       name = $3, validator = $4 WHERE id = $5">>}.
 
 {delete_client_by_id, <<"DELETE FROM clients WHERE id= $1">>}.
 
@@ -219,11 +235,18 @@
 %% If a client has been deleted, you may get back fewer than X clients
 %% and you won't know which ids were not found without parsing and
 %% inspecting what did come back.
-{bulk_get_clients,
+%% DEPRECATED as of APIv1
+{bulk_get_clients_v0,
  <<"SELECT c.id, authz_id, org_id, name, validator, admin, k.public_key, k.key_version pubkey_version,
            c.last_updated_by, c.created_at, c.updated_at
       FROM clients c
  LEFT JOIN keys k ON c.id = k.id AND key_name = 'default'
+     WHERE c.id = ANY($1)">>}.
+
+%% replace bulk_get_clients
+{bulk_get_clients,
+ <<"SELECT c.id, authz_id, org_id, name, validator, c.last_updated_by, c.created_at, c.updated_at
+      FROM clients c
      WHERE c.id = ANY($1)">>}.
 
 %% cookbook queries

--- a/apps/chef_objects/src/chef_client.erl
+++ b/apps/chef_objects/src/chef_client.erl
@@ -27,7 +27,6 @@
 
 -export([
          authz_id/1,
-         add_authn_fields/2,
          assemble_client_ejson/2,
          ejson_for_indexing/2,
          fields_for_fetch/1,
@@ -37,15 +36,16 @@
          name/1,
          org_id/1,
          new_record/4,
-         parse_binary_json/2,
          parse_binary_json/3,
+         parse_binary_json/4,
          record_fields/1,
          set_created/2,
          set_updated/2,
          set_api_version/2,
          type_name/1,
          update_from_ejson/2,
-         list/2
+         list/2,
+         fields_for_insert/1
         ]).
 
 %% database named queries
@@ -59,17 +59,6 @@
         ]).
 
 -mixin([{chef_object_default_callbacks, [ fetch/2, update/2 ]}]).
-
-
--define(DEFAULT_FIELD_VALUES, [
-                               {<<"json_class">>, <<"Chef::ApiClient">>},
-                               {<<"chef_type">>, <<"client">>},
-                               {<<"validator">>, false},
-                               {<<"private_key">>, false}
-                              ]).
-
-
-
 
 -behaviour(chef_object).
 
@@ -127,26 +116,34 @@ set_updated(#chef_client{} = Object, ActorId) ->
     Now = chef_object_base:sql_date(now),
     Object#chef_client{updated_at = Now, last_updated_by = ActorId}.
 
+create_query(#chef_client{server_api_version = ?API_v0}) ->
+    insert_client_v0;
 create_query(_ObjectRec) ->
     insert_client.
 
+update_query(#chef_client{server_api_version = ?API_v0}) ->
+    update_client_by_id_v0;
 update_query(_ObjectRec) ->
     update_client_by_id.
 
 delete_query(_ObjectRec) ->
     delete_client_by_id.
 
+find_query(#chef_client{server_api_version = ?API_v0}) ->
+    find_client_by_orgid_name_v0;
 find_query(_ObjectRec) ->
     find_client_by_orgid_name.
 
 list_query(_ObjectRec) ->
     list_clients_for_org.
 
+bulk_get_query(#chef_client{server_api_version = ?API_v0}) ->
+    bulk_get_clients_v0;
 bulk_get_query(_ObjectRec) ->
     bulk_get_clients.
 
 -spec new_record(api_version(), object_id(), object_id(), ejson_term()) -> #chef_client{}.
-new_record(ApiVersion, OrgId, AuthzId, ClientData) ->
+new_record(?API_v0 = ApiVersion, OrgId, AuthzId, ClientData) ->
     Name = ej:get({<<"name">>}, ClientData),
     Id = chef_object_base:make_org_prefix_id(OrgId, Name),
     Validator = ej:get({<<"validator">>}, ClientData) =:= true,
@@ -160,9 +157,20 @@ new_record(ApiVersion, OrgId, AuthzId, ClientData) ->
                  validator = Validator,
                  admin = Admin,
                  public_key = PublicKey,
-                 pubkey_version = PubkeyVersion}.
+                 pubkey_version = PubkeyVersion};
+new_record(ApiVersion, OrgId, AuthzId, ClientData) ->
+    Name = ej:get({<<"name">>}, ClientData),
+    Id = chef_object_base:make_org_prefix_id(OrgId, Name),
+    Validator = ej:get({<<"validator">>}, ClientData) =:= true,
+    #chef_client{server_api_version = ApiVersion,
+                 id = Id,
+                 authz_id = chef_object_base:maybe_stub_authz_id(AuthzId, Id),
+                 org_id = OrgId,
+                 name = Name,
+                 validator = Validator}.
 
-fields_for_update(#chef_client{last_updated_by = LastUpdatedBy,
+fields_for_update(#chef_client{server_api_version = ?API_v0,
+                               last_updated_by = LastUpdatedBy,
                                updated_at = UpdatedAt,
                                name = Name,
                                public_key = PublicKey,
@@ -170,88 +178,115 @@ fields_for_update(#chef_client{last_updated_by = LastUpdatedBy,
                                admin = IsAdmin,
                                validator = IsValidator,
                                id = Id}) ->
-    [LastUpdatedBy, UpdatedAt, Name,
-     PublicKey, PubkeyVersion,
-     IsValidator =:= true,
-     IsAdmin =:= true, Id].
+    [LastUpdatedBy, UpdatedAt, Name, PublicKey, PubkeyVersion,
+     IsValidator =:= true, IsAdmin =:= true, Id];
+fields_for_update(#chef_client{last_updated_by = LastUpdatedBy,
+                               updated_at = UpdatedAt,
+                               name = Name,
+                               validator = IsValidator,
+                               id = Id}) ->
+    [LastUpdatedBy, UpdatedAt, Name, IsValidator =:= true, Id].
 
 fields_for_fetch(#chef_client{org_id = OrgId,
                               name = Name}) ->
     [OrgId, Name].
 
+fields_for_insert(#chef_client{server_api_version = ?API_v0} = Client) ->
+    chef_object_default_callbacks:fields_for_insert(Client);
+fields_for_insert(#chef_client{id = Id,
+                               authz_id = AuthzId,
+                               org_id = OrgId,
+                               name = Name,
+                               validator = IsValidator,
+                               last_updated_by = LastUpdatedBy,
+                               created_at = CreatedAt, updated_at = UpdatedAt}) ->
+    [Id, AuthzId, OrgId, Name, IsValidator =:= true, LastUpdatedBy, CreatedAt, UpdatedAt].
+
 record_fields(_ApiVersion) ->
     record_info(fields, chef_client).
 
--spec add_authn_fields(ejson_term(), binary()) -> ejson_term().
-%% @doc Add in the generated public key along with other authn related
-%% fields to the EJson encoded request body. Return the modified EJson
-%% structure
-add_authn_fields(ClientData, PublicKey) ->
-    lists:foldl(fun({Key, Value}, EJson) ->
-                    ej:set({Key}, EJson, Value)
-                end,
-                ClientData,
-                [
-                    {<<"pubkey_version">>, chef_key_base:key_version(PublicKey)},
-                    {<<"public_key">>, PublicKey}
-                ]).
-
 %% @doc creates the json body for clients
 -spec assemble_client_ejson(#chef_client{}, binary()) -> ejson_term().
-assemble_client_ejson(#chef_client{name = Name, validator = Validator,
-                                      public_key = PublicKey}, OrgName) ->
-    Values = [{<<"name">>, value_or_default(Name, <<"">>)},
-              {<<"clientname">>, value_or_default(Name, <<"">>)},
-              {<<"validator">>, Validator =:= true},
-              {<<"orgname">>, OrgName},
-              {<<"json_class">>, <<"Chef::ApiClient">>},
-              {<<"chef_type">>, <<"client">>}],
+assemble_client_ejson(#chef_client{server_api_version = ?API_v0, public_key = PublicKey} = Client, OrgName) ->
+    Values = base_client_ejson(Client, OrgName),
     case PublicKey of
         undefined ->
             {Values};
         _ ->
             {[{<<"public_key">>, chef_key_base:extract_public_key(PublicKey)} | Values]}
-    end.
+    end;
+assemble_client_ejson(Client, OrgName) ->
+    { base_client_ejson(Client, OrgName) }.
+
+base_client_ejson(#chef_client{name = Name, validator = Validator}, OrgName) ->
+    [{<<"name">>, value_or_default(Name, <<"">>)},
+     {<<"clientname">>, value_or_default(Name, <<"">>)},
+     {<<"validator">>, Validator =:= true},
+     {<<"orgname">>, OrgName},
+     {<<"json_class">>, <<"Chef::ApiClient">>},
+     {<<"chef_type">>, <<"client">>}].
 
 %% @doc Convert a binary JSON string representing a Chef Client into an
 %% EJson-encoded Erlang data structure, using passed defaults
 %% @end
-parse_binary_json(Bin, ReqName) ->
-    parse_binary_json(Bin, ReqName, not_found).
+parse_binary_json(ApiVersion, Bin, ReqName) ->
+    parse_binary_json(ApiVersion, Bin, ReqName, not_found).
 
--spec parse_binary_json(binary(), binary() | undefined,
-                        not_found | #chef_client{}) -> {'ok', {[{_, _}]}}. % or throw
-parse_binary_json(Bin, ReqName, CurrentClient) ->
+-spec parse_binary_json(api_version(), binary(), binary() | undefined,
+                        not_found | #chef_client{}) -> {'ok',ej:json_object()}. % or throw
+
+parse_binary_json(ApiVersion, Bin, ReqName, CurrentClient) ->
     Client = set_values_from_current_client(chef_json:decode_body(Bin), CurrentClient),
-    Client1 = chef_object_base:set_default_values(Client, ?DEFAULT_FIELD_VALUES),
+    Client1 = chef_object_base:set_default_values(Client, default_field_values(ApiVersion)),
     {Name, FinalClient} = destination_name(Client1, ReqName),
     valid_name(Name),
-    validate_client(FinalClient, Name).
+    validate_client(ApiVersion, FinalClient, Name).
 
-validate_client(Client, Name) ->
-    case ej:valid(client_spec(Name), Client) of
-        ok -> {ok, Client};
-        Bad -> throw(Bad)
+validate_client(ApiVersion, ClientData, Name) ->
+    chef_object_base:validate_ejson(ClientData, client_spec(ApiVersion, Name)),
+    maybe_validate_public_key(ApiVersion, ClientData).
+
+maybe_validate_public_key(?API_v0 , ClientData) ->
+    % Under APIv0, we do not validate public key, which does allow
+    % a certificate to be passed in. The certificate is still handled correctly
+    % later, for auth purposes and retrieving key data, so we'll
+    % keep the behavior until vNext
+    {ok, ClientData};
+maybe_validate_public_key(_, ClientData) ->
+    case ej:get({<<"public_key">>}, ClientData) of
+        Value when Value =:= undefined;
+                   Value == <<"generate">> ->
+            {ok, ClientData};
+        _ ->
+            chef_object_base:validate_ejson(ClientData, {[ chef_key_base:public_key_spec(opt) ]})
     end.
 
-set_values_from_current_client(Client, not_found) ->
-    Client;
-set_values_from_current_client(Client, #chef_client{validator = IsValidator,
-                                                    public_key = Cert}) ->
+set_values_from_current_client(Client, #chef_client{server_api_version = ?API_v0, validator = IsValidator, public_key = Cert}) ->
     C = chef_object_base:set_default_values(Client, [{<<"validator">>, IsValidator}]),
     case chef_key_base:cert_or_key(C) of
         {undefined, _} ->
             chef_key_base:set_public_key(C, Cert);
         {_NewPublicKey, _} ->
             C
-    end.
+    end;
+set_values_from_current_client(Client, #chef_client{validator = IsValidator}) ->
+    chef_object_base:set_default_values(Client, [{<<"validator">>, IsValidator}]);
+set_values_from_current_client(Client, not_found) ->
+    Client.
 
-client_spec(Name) ->
+client_spec(?API_v0, Name) ->
     {[
       {<<"name">>, Name},
       {<<"clientname">>, Name},
       {{opt, <<"validator">>}, boolean},
       {{opt, <<"private_key">>}, boolean}
+     ]};
+client_spec(_ApiVersion, Name) ->
+    {[
+      {<<"name">>, Name},
+      {<<"clientname">>, Name},
+      {{opt, <<"public_key">>}, string},
+      {{opt, <<"validator">>}, boolean}
      ]}.
 
 
@@ -269,8 +304,7 @@ destination_name(Client, ReqName) ->
             throw({both_missing, <<"name">>, <<"clientname">>});
         {undefined, undefined, ReqName} ->
             %% a PUT with only name found in URL, set both in body
-            {ReqName, ej:set({<<"name">>}, ej:set({<<"clientname">>},
-                                                  Client, ReqName), ReqName)};
+            {ReqName, ej:set({<<"name">>}, ej:set({<<"clientname">>}, Client, ReqName), ReqName)};
         {Name, Name, _} ->
             %% POST or PUT with with name == clientname
             {Name, Client};
@@ -302,7 +336,17 @@ value_or_default(Value, _) ->
 list(#chef_client{org_id = OrgId} = Rec, CallbackFun) ->
     CallbackFun({list_query(Rec), [OrgId], [name]}).
 
-
+default_field_values(?API_v0) ->
+     [ {<<"json_class">>, <<"Chef::ApiClient">>},
+       {<<"chef_type">>, <<"client">>},
+       {<<"validator">>, false},
+       {<<"private_key">>, false}
+     ];
+default_field_values(_) ->
+     [ {<<"json_class">>, <<"Chef::ApiClient">>},
+       {<<"chef_type">>, <<"client">>},
+       {<<"validator">>, false}
+     ].
 
 set_api_version(ObjectRec, Version) ->
     ObjectRec#chef_client{server_api_version = Version}.

--- a/apps/chef_objects/test/chef_client_tests.erl
+++ b/apps/chef_objects/test/chef_client_tests.erl
@@ -50,7 +50,8 @@ cert_data() ->
 assemble_client_ejson_test_() ->
     [{"obtain expected EJSON",
       fun() ->
-              Client = #chef_client{name = <<"alice">>,
+              Client = #chef_client{server_api_version = ?API_MIN_VER,
+                                    name = <<"alice">>,
                                     admin = true,
                                     validator = false,
                                     public_key = public_key_data()},
@@ -68,7 +69,8 @@ assemble_client_ejson_test_() ->
       end},
      {"converts certificate to public key",
       fun() ->
-              Client = #chef_client{name = <<"alice">>,
+              Client = #chef_client{server_api_version = ?API_MIN_VER,
+                                    name = <<"alice">>,
                                     admin = true,
                                     validator = false,
                                     public_key = cert_data()},
@@ -92,13 +94,13 @@ parse_binary_json_test_() ->
     [{"Error thrown on mismatched names",
       fun() ->
           Body = <<"{\"name\":\"name\",\"clientname\":\"notname\"}">>,
-          ?assertThrow({client_name_mismatch}, chef_client:parse_binary_json(Body, <<"name">>))
+          ?assertThrow({client_name_mismatch}, chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>))
       end
      },
      {"Can create with only name",
       fun() ->
           Body = <<"{\"name\":\"name\"}">>,
-          {ok, Client} = chef_client:parse_binary_json(Body, <<"name">>),
+          {ok, Client} = chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>),
           Name = ej:get({<<"name">>}, Client),
           ClientName = ej:get({<<"clientname">>}, Client),
           ?assertEqual(Name, ClientName)
@@ -107,7 +109,7 @@ parse_binary_json_test_() ->
      {"Can create with only clientname",
       fun() ->
           Body = <<"{\"clientname\":\"name\"}">>,
-          {ok, Client} = chef_client:parse_binary_json(Body, <<"name">>),
+          {ok, Client} = chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>),
           Name = ej:get({<<"name">>}, Client),
           ClientName = ej:get({<<"clientname">>}, Client),
           ?assertEqual(Name, ClientName)
@@ -117,7 +119,7 @@ parse_binary_json_test_() ->
       fun() ->
           Body = <<"{\"validator\":false}">>,
           ?assertThrow({both_missing, <<"name">>, <<"clientname">>},
-                       chef_client:parse_binary_json(Body, undefined))
+                       chef_client:parse_binary_json(?API_MIN_VER, Body, undefined))
       end
      },
      {"Error thrown with bad name",
@@ -125,7 +127,7 @@ parse_binary_json_test_() ->
           Body = <<"{\"name\":\"bad~name\"}">>,
           ?assertThrow({bad_client_name, <<"bad~name">>,
                         <<"Malformed client name.  Must be A-Z, a-z, 0-9, _, -, or .">>},
-                       chef_client:parse_binary_json(Body, <<"bad~name">>))
+                       chef_client:parse_binary_json(?API_MIN_VER, Body, <<"bad~name">>))
       end
      }
     ].

--- a/apps/oc_chef_wm/src/chef_wm_clients.erl
+++ b/apps/oc_chef_wm/src/chef_wm_clients.erl
@@ -82,12 +82,12 @@ validate_request('GET', Req, #base_state{organization_guid = OrgId} = State) ->
     %% code for generating the map of name => URL returned for GET /clients.  OrgId is set via
     %% malformed_request.
     {Req, State#base_state{resource_state = #chef_client{org_id = OrgId}}};
-validate_request('POST', Req, State) ->
+validate_request('POST', Req, #base_state{server_api_version = ApiVersion} = State) ->
     case wrq:req_body(Req) of
         undefined ->
             throw({error, missing_body});
         Body ->
-            {ok, Client} = chef_client:parse_binary_json(Body, undefined),
+            {ok, Client} = chef_client:parse_binary_json(ApiVersion, Body, undefined),
             {Req, State#base_state{superuser_bypasses_checks = true,
                     resource_state = #client_state{client_data = Client}}}
     end.

--- a/apps/oc_chef_wm/src/chef_wm_named_client.erl
+++ b/apps/oc_chef_wm/src/chef_wm_named_client.erl
@@ -77,7 +77,7 @@ validate_any_request(Req, #base_state{chef_db_context = DbContext,
     ClientState1 = ClientState#client_state{chef_client = Client},
     {Req, State#base_state{resource_state = ClientState1}}.
 
-validate_request('PUT', Req, State) ->
+validate_request('PUT', Req, #base_state{server_api_version = ApiVersion} = State) ->
     {Req1, State1} = validate_any_request(Req, State),
     #base_state{resource_state =
                     #client_state{chef_client = OldClient} = ClientState} = State1,
@@ -91,7 +91,7 @@ validate_request('PUT', Req, State) ->
             % the old client from the database in the first place.
             #chef_client{name = Name} = OldClient,
             Body = wrq:req_body(Req),
-            {ok, ClientData} = chef_client:parse_binary_json(Body, Name, OldClient),
+            {ok, ClientData} = chef_client:parse_binary_json(ApiVersion, Body, Name, OldClient),
             {Req1, State1#base_state{resource_state =
                                          ClientState#client_state{client_data =
                                                                       ClientData}}}

--- a/include/chef_types.hrl
+++ b/include/chef_types.hrl
@@ -94,10 +94,11 @@
           'org_id' :: object_id(),          % organization guid
           'name' :: binary(),               % name of client
           'validator' = false :: boolean(),         % boolean; true if this is a validator
+           % BEGIN DEPRECATED APIv1
           'admin' = false :: boolean(),             % true if this is an admin user
-          'public_key' :: binary(),         % public key cert
-          'pubkey_version' :: ?KEY_VERSION | ?CERT_VERSION,
-                                            % version/type of public key (certificate)
+          'public_key' :: binary(),         % public key
+          'pubkey_version' :: ?KEY_VERSION | ?CERT_VERSION, % 0 = key, 1 = cert %
+           % END DEPRECATED APIv1
           'last_updated_by' :: object_id(), % authz guid of last actor to update object
           'created_at' :: binary(), % time created at
           'updated_at' :: binary()  % time created at


### PR DESCRIPTION
* enable incoming key validation for clients under api v1. This will
  have the effect of preventing clients from uploading certificates
  when using v1+
* v0 behavior is explict, while v1 and later are the fall-through
  case.

Additional note: under v0, we have no client key validation -- which made
it possible for a certificate to be uploaded in client. Validation was added
under v1 to avoid a breaking change to v0.

ChangeLog-Entry: [internal] chef client support for enable support for chef

----
5 / 8 I've split these into separate PRs to make the changes clearer, but am currently planning to merge all 8 down into master as a unit. 

/ping @chef/lob 