### PR TITLE
Fixed dialyzer error in chef_wm_depsolver

### DIFF
--- a/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -290,9 +290,7 @@ assemble_response(Req, State, CookbookVersions) ->
             CBMapJson = chef_json:encode(JsonList),
             {true, wrq:append_to_response_body(CBMapJson, Req), State};
         {error, Msg} ->
-            forbid(Req, State, Msg, {forbidden, read});
-        {timeout, Msg} ->
-            server_error(Req, State, Msg, {timeout, cookbook_authz})
+            forbid(Req, State, Msg, {forbidden, read})
     end.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
I really didn't want to believe dialyzer on this one, but you can't ever reach

```erlang
{timeout, Msg}
```

The timeout happens all the way down in `ibrowse` but it's returned as `{error, req_timedout}`, which is caught in `oc_chef_wm_base:check_cookbook_authz` and wrapped in `erlang:error/1` so dialyzer was right!