### PR TITLE
depsolver dialyzer issue fixed

### DIFF
--- a/apps/depsolver/src/depsolver.erl
+++ b/apps/depsolver/src/depsolver.erl
@@ -190,6 +190,8 @@ filter_pvpair_by_constraint(PVPair, Constraints) ->
 
 -spec filter_package({pkg_name(), vsn()}, constraint()) ->
                             boolean().
+filter_package({PkgName, Vsn}, PkgName) ->
+    is_version_within_constraint(Vsn, PkgName);
 filter_package({PkgName, Vsn}, C = {PkgName, _}) ->
     is_version_within_constraint(Vsn, C);
 filter_package({PkgName, Vsn}, C = {PkgName, _, _}) ->

--- a/include/oc_chef_wm.hrl
+++ b/include/oc_chef_wm.hrl
@@ -159,7 +159,7 @@
           requestor_id :: object_id(),
 
           %% Details for The actor making the request.
-          requestor :: #chef_requestor{},
+          requestor :: #chef_requestor{} | #chef_client{},
 
           %% A record containing resource-specific state.
           resource_state :: tuple(),


### PR DESCRIPTION
there's a small chance that if the version is `{missing}` we were returning true, but probably should have been false.