### PR TITLE
Use static version number in apps/

### DIFF
--- a/apps/chef_db/src/chef_db.app.src
+++ b/apps/chef_db/src/chef_db.app.src
@@ -19,7 +19,7 @@
 {application, chef_db,
  [
   {description, "Database abstraction layer for Chef server"},
-  {vsn, git},
+  {vsn, "0"},
   {registered, []},
   {applications, [
                   kernel,

--- a/apps/chef_index/src/chef_index.app.src
+++ b/apps/chef_index/src/chef_index.app.src
@@ -18,7 +18,7 @@
 {application, chef_index,
  [
   {description, "Chef search index tools"},
-  {vsn, git},
+  {vsn, "0"},
   {registered, []},
   {applications, [
                   kernel,

--- a/apps/chef_objects/src/chef_objects.app.src
+++ b/apps/chef_objects/src/chef_objects.app.src
@@ -18,7 +18,7 @@
 {application, chef_objects,
  [
   {description, "Chef object types and support modules"},
-  {vsn, git},
+  {vsn, "0"},
   {registered, []},
   {applications, [
                   kernel,

--- a/apps/chef_test/src/chef_test.app.src
+++ b/apps/chef_test/src/chef_test.app.src
@@ -22,7 +22,7 @@
 {application, chef_test,
  [
   {description, ""},
-  {vsn, "1"},
+  {vsn, "0"},
   {registered, []},
   {applications, [
                   kernel,

--- a/apps/depsolver/src/depsolver.app.src
+++ b/apps/depsolver/src/depsolver.app.src
@@ -22,6 +22,6 @@
 
 {application, depsolver,
  [{description, "Package Constraint Solver"},
-  {vsn, "1.1.0"},
+  {vsn, "0"},
   {modules, []},
   {applications, [kernel, stdlib]}]}.

--- a/apps/oc_chef_authz/src/oc_chef_authz.app.src
+++ b/apps/oc_chef_authz/src/oc_chef_authz.app.src
@@ -18,7 +18,7 @@
 {application, oc_chef_authz,
  [
   {description, "Opscode authz client"},
-  {vsn, "3.0.0"},
+  {vsn, "0"},
   {registered, []},
   {applications, [kernel,
                   stdlib,

--- a/apps/oc_chef_wm/src/oc_chef_wm.app.src
+++ b/apps/oc_chef_wm/src/oc_chef_wm.app.src
@@ -4,7 +4,7 @@
 {application, oc_chef_wm,
  [
   {description, "Base bits needed to write Web Machine API endpoints"},
-  {vsn, "0.1.0"},
+  {vsn, "0"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
Half of the apps were already using a static version number.  The git
based vsn won't work after the combined merge since omnibus will be
building from a directory without git information.