### PR TITLE
Api v1 - clients, users v1 REST support

### DIFF
--- a/apps/chef_db/priv/pgsql_statements.config
+++ b/apps/chef_db/priv/pgsql_statements.config
@@ -203,8 +203,8 @@
    "  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)">>}.
 
 {insert_client,
- <<"INSERT INTO clients ( id, authz_id, org_id, name, validator, last_updated_by, created_at, updated_at )"
-   "  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)">>}.
+ <<"INSERT INTO clients ( id, authz_id, org_id, name, validator, last_updated_by, created_at, updated_at, pubkey_version, admin )"
+   "  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 0, false)">>}.
 
 % DEPRECATED as of APIv1
 {update_client_by_id_v0,
@@ -453,8 +453,8 @@
 {insert_user,
   <<"INSERT INTO users (id, authz_id, username, email, hashed_password, salt,
      hash_type, last_updated_by, created_at, updated_at, external_authentication_uid,
-      recovery_authentication_enabled, serialized_object, admin) VALUES
-      ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, false)">>}.
+      recovery_authentication_enabled, serialized_object, admin, pubkey_version) VALUES
+      ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, false, 0)">>}.
 
 {insert_user_v0,
   <<"INSERT INTO users (id, authz_id, username, email, public_key, pubkey_version,
@@ -541,6 +541,7 @@
          username = $8,
          last_updated_by = $9,
          updated_at = $10,
-         admin = false
-  WWHERE id = $11">>
+         admin = false,
+         pubkey_version = 0
+  WHERE  id = $11">>
 }.

--- a/apps/chef_db/src/chef_db.erl
+++ b/apps/chef_db/src/chef_db.erl
@@ -217,10 +217,8 @@ delete(ObjectRec, #context{server_api_version = ApiVersion, reqid = ReqId}) ->
                    not_found |
                    {error, term()}.
 fetch(ObjectRec, #context{server_api_version = ApiVersion, reqid = ReqId}) ->
-    % TODO - base branch!
     ObjectRec2 = chef_object:set_api_version(ObjectRec, ApiVersion),
     Result = ?SH_TIME(ReqId, chef_sql, fetch, (ObjectRec2)),
-    % TODO - base branch ^
     case Result of
         not_found ->
             Result;

--- a/apps/chef_objects/src/chef_key.erl
+++ b/apps/chef_objects/src/chef_key.erl
@@ -40,17 +40,14 @@
          set_updated/2,
          set_api_version/2,
          new_record/4,
+         default_key_ejson/1,
          name/1,
          id/1,
          org_id/1,
          type_name/1,
          delete/2,
          parse_binary_json/2,
-         fields_for_insert/1
-        ]).
-
-%% database named queries
--export([
+         fields_for_insert/1,
          create_query/1,
          update_query/1,
          delete_query/1,
@@ -147,6 +144,11 @@ new_record(ApiVersion, _OrgId, _AuthzId, {Id, KeyData}) ->
               public_key = PubKey, key_version = PubKeyVersion,
               expires_at = Expires}.
 
+default_key_ejson(PublicKey ) ->
+    {[{<<"name">>, <<"default">>},
+      {<<"public_key">>, PublicKey},
+      {<<"expiration_date">>, <<"infinity">>}]}.
+
 safe_key_version(PublicKey) ->
     try chef_key_base:key_version(PublicKey) of
         Result -> Result
@@ -183,13 +185,13 @@ parse_binary_json(Bin, update) ->
           throw(missing_required_field);
       _ ->
           validate_name(opt, EJ),
-          chef_key_base:validate_public_key_fields(opt, EJ),
+          chef_key_base:validate_public_key_fields(opt, EJ, key, update),
           validate_expiration_date(opt, EJ)
   end;
 parse_binary_json(Bin, create) ->
   EJ = chef_json:decode(Bin),
   validate_name(req, EJ),
-  chef_key_base:validate_public_key_fields(req, EJ),
+  chef_key_base:validate_public_key_fields(req, EJ, key, create),
   validate_expiration_date(req, EJ).
 
 validate_expiration_date(Required, EJ) ->

--- a/apps/chef_objects/src/chef_user.erl
+++ b/apps/chef_objects/src/chef_user.erl
@@ -24,8 +24,7 @@
 -include_lib("ej/include/ej.hrl").
 -include("../../include/chef_types.hrl").
 
--export([
-         assemble_user_ejson/2,
+-export([assemble_user_ejson/2,
          authz_id/1,
          ejson_for_indexing/2,
          fetch/2,
@@ -114,7 +113,28 @@ serialized_field_value(FieldName, #chef_user{serialized_object = SerializedObjec
     ej:get({FieldName}, EJ).
 
 -spec new_record(api_version(), object_id(), object_id(), ejson_term()) -> #chef_user{}.
+new_record(?API_v0 = ApiVersion, OrgId, AuthzId, Data) ->
+    User = common_new_record(ApiVersion, AuthzId, Data),
+    #chef_user{username = UserName} = User,
+    Id = chef_object_base:make_org_prefix_id(OrgId, UserName),
+    {PublicKey, PubKeyVersion} = chef_key_base:cert_or_key(Data),
+    User#chef_user{id = Id, public_key = PublicKey,
+                   pubkey_version = PubKeyVersion,
+                   authz_id = chef_object_base:maybe_stub_authz_id(AuthzId, Id) };
 new_record(ApiVersion, OrgId, AuthzId, Data) ->
+    User = common_new_record(ApiVersion, AuthzId, Data),
+    Id = case ej:get({<<"id">>}, Data) of
+            undefined ->
+                #chef_user{username = UserName} = User,
+                chef_object_base:make_org_prefix_id(OrgId, UserName);
+            UserId ->
+                UserId
+         end,
+    User#chef_user{id = Id,
+                   authz_id = chef_object_base:maybe_stub_authz_id(AuthzId, Id) }.
+
+
+common_new_record(ApiVersion, AuthzId, Data) ->
     {HashPass, Salt, HashType} = case ej:get({<<"password">>}, Data) of
         undefined ->
             {null, null, null};
@@ -122,20 +142,15 @@ new_record(ApiVersion, OrgId, AuthzId, Data) ->
             chef_password:encrypt(Password)
     end,
     UserData = ej:delete({<<"password">>}, Data),
-    Name = username_from_ejson(UserData),
-    Id = chef_object_base:make_org_prefix_id(OrgId, Name),
+    Name = username_from_ejson(Data),
     Email = value_or_null({<<"email">>}, UserData),
     ExtAuthUid = value_or_null({<<"external_authentication_uid">>}, UserData),
     EnableRecovery = ej:get({<<"recovery_authentication_enabled">>}, UserData) =:= true,
-    {PublicKey, PubkeyVersion} = chef_key_base:cert_or_key(UserData),
     SerializedObject = { whitelisted_values(UserData, ?JSON_SERIALIZABLE) },
     #chef_user{server_api_version = ApiVersion,
-               id = Id,
-               authz_id = chef_object_base:maybe_stub_authz_id(AuthzId, Id),
                username = Name,
+               authz_id = AuthzId,
                email = Email,
-               pubkey_version = PubkeyVersion,
-               public_key = PublicKey,
                hashed_password = HashPass,
                salt = Salt,
                hash_type = HashType,
@@ -233,31 +248,30 @@ valid_password(_Password) ->
 whitelisted_values(EJ, Permitted) ->
     [{X, ej:get({X}, EJ) } || X <- Permitted, ej:get({X}, EJ)  =/= undefined ].
 
-assemble_user_ejson(#chef_user{username = Name,
-                               public_key = KeyOrCert,
-                               email = Email,
-                               serialized_object = SerializedObject},
-                    _OrgId) ->
-    EJ = chef_json:decode(SerializedObject ),
+assemble_user_ejson(#chef_user{server_api_version = ?API_v0,
+                               public_key = KeyOrCert} = User, _OrgId) ->
     % public_key can mean either public key or cert.
     % if it's a cert, we need to extract the public key -
     % we don't want to hand the cert back on user GET.
-    RealPubKey = chef_key_base:extract_public_key(KeyOrCert),
+    { common_user_ejson(User) ++
+      [{<<"public_key">>, chef_key_base:extract_public_key(KeyOrCert)}] };
+assemble_user_ejson(User, _OrgId) ->
+    { common_user_ejson(User) }.
+
+common_user_ejson(#chef_user{username = Name,
+                             email = Email,
+                             serialized_object = SerializedObject}) ->
+    EJ = chef_json:decode(SerializedObject),
     % Where external auth is enable, email may be null/undefined
     Email2 = case Email of
         undefined -> <<"">>;
         null -> <<"">>;
         _ -> Email
     end,
-
-    User1 = [{<<"username">>, Name},
-             {<<"public_key">>, RealPubKey},
-             {<<"email">>, Email2}],
+    User1 = [{<<"username">>, Name}, {<<"email">>, Email2}],
     User2 = whitelisted_values(EJ, ?JSON_SERIALIZABLE ++
                                [ <<"recovery_authentication_enabled">>, <<"external_authentication_uid">>] ),
-
-    { User1 ++ User2 }.
-
+    User1 ++ User2.
 
 %% @doc Convert a binary JSON string representing a Chef User into an
 %% EJson-encoded Erlang data structure.
@@ -266,33 +280,44 @@ parse_binary_json(ApiVersion, Bin) ->
     parse_binary_json(ApiVersion, Bin, create, undefined).
 
 -spec parse_binary_json(api_version(), binary(), create | update, #chef_user{} | undefined) -> {ok, ej:json_object()}. % or throw
-parse_binary_json(_ApiVersion, Bin, Operation, User) ->
+parse_binary_json(?API_v0, Bin, Operation, User) ->
     EJ = delete_null_public_key(chef_json:decode(Bin)),
-    EJson = case ej:get({<<"private_key">>}, EJ) of
+    EJ1 = case ej:get({<<"private_key">>}, EJ) of
         true ->
             ej:delete({<<"public_key">>}, EJ);
         _ ->
-            validate_user(EJ, {[ chef_key_base:public_key_spec(opt) ]}),
+            chef_object_base:validate_ejson(EJ, {[ chef_key_base:public_key_spec(opt) ]}),
             EJ
     end,
+    common_user_validation(EJ1, User, Operation);
+parse_binary_json(_ApiVersion, Bin, Operation, User) ->
+    % We no longer accept key, this will fail if public_key, create_key, or private_key
+    % indicators are present.
+    EJ = chef_json:decode(Bin),
+    chef_key_base:validate_public_key_fields(opt, EJ, user, Operation),
+    common_user_validation(EJ, User, Operation),
+    {ok, EJ}.
 
-    validate_user_name(EJson),
+common_user_validation(EJ, User, Operation) ->
+    validate_user_name(EJ),
     %% If user is invalid, an error is thrown
-    validate_user(EJson, user_spec(common)),
-    validate_user(EJson, user_spec(Operation)),
+    chef_object_base:validate_ejson(EJ, user_spec(common)),
+    chef_object_base:validate_ejson(EJ, user_spec(Operation)),
 
     %% IF user is internally authenticated, some additional fields
     %% (common to both ops) are required. In the case where
     %% external auth id is not provided in the ejson/request,
     %% we'll use the existing data in the user record itself.
-    case external_auth_uid(EJson, User) of
+    case external_auth_uid(EJ, User) of
         undefined ->
-            validate_user(EJson, local_auth_user_spec(common)),
-            validate_user(EJson, local_auth_user_spec(Operation));
+            chef_object_base:validate_ejson(EJ, local_auth_user_spec(common)),
+            chef_object_base:validate_ejson(EJ, local_auth_user_spec(Operation));
          _ ->
             ok
     end,
-    {ok, EJson}.
+    % Ensure the user can't set this - we make use of it in some cases by setting it internally
+    EJ1 = ej:delete({<<"id">>}, EJ),
+    {ok, EJ1}.
 
 external_auth_uid(EJson, #chef_user{external_authentication_uid = ExtAuthUid}) ->
     case ej:get({<<"external_authentication_uid">>}, EJson) of
@@ -316,10 +341,6 @@ delete_null_public_key(Ejson) ->
         _ ->
             Ejson
     end.
-
-%%-spec validate_user(ejson_term(), ejson_term()) -> {ok, ejson_term()}. % or throw
-validate_user(User, Spec) ->
-  chef_object_base:validate_ejson(User, Spec).
 
 % Our user spec does not include 'username' because one of
 % 'name'|'username' may be present. Check for either/or here,
@@ -355,7 +376,23 @@ set_password_data(#chef_user{}=User, {HashedPassword, Salt, HashType}) ->
 %% @doc Return a new `chef_user()' record updated according to the specified EJSON
 %% terms. This provides behavior similar to chef_objects:update_from_ejson()
 -spec update_from_ejson(#chef_user{}, ejson_term()) -> #chef_user{}.
+update_from_ejson(#chef_user{server_api_version = ?API_v0} = User, UserEJson) ->
+    User1 = update_from_ejson_common(User, UserEJson),
+    {Key, Version} = chef_key_base:cert_or_key(UserEJson),
+    case Key of
+        undefined ->
+            User1;
+        _ ->
+            User1#chef_user{
+                pubkey_version= Version,
+                % Note: public_key is now potentially a certificate...
+                public_key = Key
+            }
+    end;
 update_from_ejson(#chef_user{} = User, UserEJson) ->
+    update_from_ejson_common(User, UserEJson).
+
+update_from_ejson_common(User, UserEJson) ->
     User1 = case ej:get({<<"password">>}, UserEJson) of
         NewPassword when is_binary(NewPassword) ->
             chef_user:set_password_data(User, chef_password:encrypt(NewPassword));
@@ -370,26 +407,15 @@ update_from_ejson(#chef_user{} = User, UserEJson) ->
     RecoveryAuthenticationEnabled = value_or_existing({<<"recovery_authentication_enabled">>},
                                                       UserEJson,
                                                       User#chef_user.recovery_authentication_enabled) =:= true,
-    {Key, Version} = chef_key_base:cert_or_key(UserEJson),
-
-    User2 = case Key of
-        undefined ->
-            User1;
-        _ ->
-            User1#chef_user{
-                pubkey_version= Version,
-                % Note: public_key is now potentially a certificate...
-                public_key = Key
-            }
-    end,
     SerializedObject0 = { whitelisted_values(UserEJson, ?JSON_SERIALIZABLE) },
-    SerializedObject1 = merge_user_data(chef_json:decode(User2#chef_user.serialized_object),
+    SerializedObject1 = merge_user_data(chef_json:decode(User1#chef_user.serialized_object),
                                         SerializedObject0),
-    User2#chef_user{username = Name,
-                    email = Email,
-                    external_authentication_uid = ExternalAuthenticationUid,
-                    recovery_authentication_enabled = RecoveryAuthenticationEnabled,
-                    serialized_object = chef_json:encode(SerializedObject1)}.
+    User1#chef_user{username = Name,
+                   email = Email,
+                   external_authentication_uid = ExternalAuthenticationUid,
+                   recovery_authentication_enabled = RecoveryAuthenticationEnabled,
+                   serialized_object = chef_json:encode(SerializedObject1)}.
+
 
 merge_user_data(User, {ModData}) ->
     % If value in ModData is null, delete from user, otherwise replace or insert the value.

--- a/apps/chef_objects/test/chef_client_tests.erl
+++ b/apps/chef_objects/test/chef_client_tests.erl
@@ -26,6 +26,290 @@
 -include_lib("ej/include/ej.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(VD(D), test_utils:versioned_desc(Version,D)).
+-define(VDD(D), test_utils:versioned_desc(Version, iolist_to_binary(["[deprecated] ", D]))).
+
+
+assemble_client_ejson_test_() ->
+    test_utils:make_deprecated_tests(fun assemble_client_ejson_deprecated_tests/1) ++
+    test_utils:make_non_deprecated_tests(fun assemble_client_ejson_non_deprecated_tests/1).
+
+assemble_client_ejson_deprecated_tests(Version) ->
+    [{?VDD("obtain expected EJSON"),
+      fun() ->
+              Client = #chef_client{server_api_version = Version,
+                                    name = <<"alice">>,
+                                    admin = true,
+                                    validator = false,
+                                    public_key = public_key_data()},
+              {GotList} = chef_client:assemble_client_ejson(Client, <<"ponyville">>),
+              FilteredList = chomp_key_in_json_list(GotList),
+              ExpectedData = [{<<"json_class">>, <<"Chef::ApiClient">>},
+                              {<<"chef_type">>, <<"client">>},
+                              {<<"public_key">>, public_key_data()},
+                              {<<"validator">>, false},
+                              {<<"name">>, <<"alice">>},
+                              {<<"clientname">>, <<"alice">>},
+                              {<<"orgname">>, <<"ponyville">>}
+                             ],
+              ?assertEqual(lists:sort(ExpectedData), lists:sort(FilteredList))
+      end},
+     {?VDD("converts certificate to public key"),
+      fun() ->
+              Client = #chef_client{server_api_version = Version,
+                                    name = <<"alice">>,
+                                    admin = true,
+                                    validator = false,
+                                    public_key = cert_data()},
+              {GotList} = chef_client:assemble_client_ejson(Client, <<"ponyville">>),
+              FilteredList = chomp_key_in_json_list(GotList),
+              ExpectedData = [{<<"json_class">>, <<"Chef::ApiClient">>},
+                              {<<"chef_type">>, <<"client">>},
+                              {<<"public_key">>, public_key_data()},
+                              {<<"validator">>, false},
+                              {<<"name">>, <<"alice">>},
+                              {<<"clientname">>, <<"alice">>},
+                              {<<"orgname">>, <<"ponyville">>}
+                             ],
+              ?assertEqual(lists:sort(ExpectedData), lists:sort(FilteredList))
+      end}
+    ].
+
+
+assemble_client_ejson_non_deprecated_tests(Version) ->
+    [{?VD("obtain expected EJSON"),
+      fun() ->
+              Client = #chef_client{server_api_version = Version,
+                                    name = <<"alice">>,
+                                    validator = false },
+              {GotList} = chef_client:assemble_client_ejson(Client, <<"ponyville">>),
+              ExpectedData = [{<<"json_class">>, <<"Chef::ApiClient">>},
+                              {<<"chef_type">>, <<"client">>},
+                              {<<"validator">>, false},
+                              {<<"name">>, <<"alice">>},
+                              {<<"clientname">>, <<"alice">>},
+                              {<<"orgname">>, <<"ponyville">>}
+                             ],
+              ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
+      end}
+    ].
+
+parse_binary_json_test_() ->
+    test_utils:make_all_versions_tests(fun parse_binary_json_tests/1) ++
+    test_utils:make_deprecated_tests(fun parse_binary_json_deprecated_tests/1) ++
+    test_utils:make_non_deprecated_tests(fun parse_binary_json_non_deprecated_tests/1).
+
+
+%% These are stable behaviors across all supported api versions.
+parse_binary_json_tests(Version) ->
+    [{?VD("Error thrown on mismatched names in create"),
+     fun() ->
+         Body = <<"{\"name\":\"name\",\"clientname\":\"notname\"}">>,
+         ?assertThrow({client_name_mismatch}, chef_client:parse_binary_json(Version, Body, undefined))
+     end},
+     {?VD("Error thrown on mismatched names in update"),
+      fun() ->
+          Body = <<"{\"name\":\"name\",\"clientname\":\"notname\"}">>,
+          ?assertThrow({client_name_mismatch}, chef_client:parse_binary_json(Version, Body, undefined))
+      end},
+     {?VD("Can create with only name"),
+      fun() ->
+          Body = <<"{\"name\":\"name\"}">>,
+          {ok, Client} = chef_client:parse_binary_json(Version, Body, undefined),
+          Name = ej:get({<<"name">>}, Client),
+          ClientName = ej:get({<<"clientname">>}, Client),
+          ?assertEqual(Name, ClientName)
+      end},
+     {?VD("Can create with only clientname"),
+      fun() ->
+          Body = <<"{\"clientname\":\"name\"}">>,
+          {ok, Client} = chef_client:parse_binary_json(Version, Body, undefined),
+          Name = ej:get({<<"name">>}, Client),
+          ClientName = ej:get({<<"clientname">>}, Client),
+          ?assertEqual(Name, ClientName)
+      end},
+     {?VD("Error thrown with no name or clientname"),
+      fun() ->
+          Body = <<"{\"validator\":false}">>,
+          ?assertThrow({both_missing, <<"name">>, <<"clientname">>},
+                       chef_client:parse_binary_json(Version, Body, undefined))
+      end},
+     {?VD("Error thrown with bad name"),
+      fun() ->
+          Body = <<"{\"name\":\"bad~name\"}">>,
+          ?assertThrow({bad_client_name, <<"bad~name">>,
+                        <<"Malformed client name.  Must be A-Z, a-z, 0-9, _, -, or .">>},
+                       chef_client:parse_binary_json(Version, Body, undefined))
+      end}
+    ].
+
+
+parse_binary_json_deprecated_tests(Version) ->
+    [
+     {?VDD("Accepted when private_key is included for create or update"),
+      fun() ->
+          Body = chef_json:encode({[{ <<"private_key">>, true }, { name, <<"a_name">> }]}),
+          ?assertMatch({ok, _},
+                       chef_client:parse_binary_json(Version, Body, undefined)),
+          ?assertMatch({ok, _},
+                       chef_client:parse_binary_json(Version, Body, #chef_client{}))
+      end},
+     {?VDD("Accepted when public_key is included for create or update"),
+      fun() ->
+          Body = chef_json:encode({[{ <<"public_key">>, public_key_data()}, { name, <<"a_name">> }]}),
+          ?assertMatch({ok, _},
+                       chef_client:parse_binary_json(Version, Body, #chef_client{})),
+          ?assertMatch({ok, _},
+                       chef_client:parse_binary_json(Version, Body, undefined))
+      end}
+    ].
+
+
+% Once the behavior they replace is retired, move these tests in parse_binary_json_test_
+parse_binary_json_non_deprecated_tests(Version) ->
+    [
+     {?VD("Error thrown when private_key is included for create or update"),
+      fun() ->
+          Body = chef_json:encode({[{ <<"private_key">>, true }, { name, <<"a_name">> }]}),
+          ?assertThrow(private_key_field_not_supported,
+                       chef_client:parse_binary_json(Version, Body, undefined)),
+          ?assertThrow(private_key_field_not_supported,
+                       chef_client:parse_binary_json(Version, Body, #chef_client{}))
+      end},
+     {?VD("Error thrown when public_key is included for update"),
+      fun() ->
+          Body = chef_json:encode({[{ <<"public_key">>, public_key_data()}, { name, <<"a_name">> }]}),
+          ?assertThrow(key_management_not_supported,
+                       chef_client:parse_binary_json(Version, Body, #chef_client{}))
+      end},
+     {?VD("Error thrown zero when create_key is included for update"),
+      fun() ->
+          Body = chef_json:encode({[{ <<"create_key">>, true}, {name, <<"a_name">> }]}),
+          ?assertThrow(key_management_not_supported,
+                       chef_client:parse_binary_json(Version, Body, #chef_client{}))
+      end}
+   ].
+
+
+new_record_test_() ->
+    test_utils:make_deprecated_tests(fun new_record_deprecated_tests/1) ++
+    test_utils:make_non_deprecated_tests(fun new_record_tests/1).
+
+
+new_record_tests(Version) ->
+    [
+     {?VD("new_record creates a correct new record without admin or public key data"),
+      fun() ->
+        PubkeyData = public_key_data(),
+        OrgId = <<"12345678123456781234567812345678">>,
+        AuthzId = <<"00000000000000000000000011111111">>,
+        ClientData = {[{<<"name">>, <<"my-client">>},
+                       {<<"alpha">>, <<"bravo">>}, % Ignored
+                       {<<"admin">>, true}, % Ignored
+                       {<<"validator">>, true},
+                       {<<"public_key">>, PubkeyData}]}, % Ignored
+        Client = chef_client:new_record(Version, OrgId, AuthzId, ClientData),
+        ?assertMatch(#chef_client{server_api_version = Version,
+                                 org_id = OrgId,
+                                 authz_id = AuthzId,
+                                 admin = false, % we default false in the record
+                                 validator = true,
+                                 name = <<"my-client">>,
+                                 public_key = undefined,
+                                 pubkey_version = undefined}, Client)
+
+
+     end}
+   ].
+
+new_record_deprecated_tests(Version) ->
+    [
+     {?VD("new_record creates a correct new record"),
+      fun() ->
+        PubkeyData = public_key_data(),
+        OrgId = <<"12345678123456781234567812345678">>,
+        AuthzId = <<"00000000000000000000000011111111">>,
+        ClientData = {[{<<"name">>, <<"my-client">>},
+                       {<<"alpha">>, <<"bravo">>}, % Ignored
+                       {<<"admin">>, true},
+                       {<<"validator">>, true},
+                       {<<"public_key">>, PubkeyData}]},
+        Client = chef_client:new_record(Version, OrgId, AuthzId, ClientData),
+        ?assertMatch(#chef_client{server_api_version = Version,
+                                  org_id = OrgId,
+                                  authz_id = AuthzId,
+                                  admin = true,
+                                  validator = true,
+                                  name = <<"my-client">>,
+                                  public_key = PubkeyData,
+                                  pubkey_version = ?KEY_VERSION}, Client)
+
+     end}
+    ].
+
+update_from_ejson_test_() ->
+    test_utils:make_deprecated_tests(fun update_from_ejson_deprecated_tests/1) ++
+    test_utils:make_non_deprecated_tests(fun update_from_ejson_tests/1) ++
+    test_utils:make_all_versions_tests(fun update_from_ejson_common_tests/1).
+
+update_from_ejson_tests(Version) ->
+    [
+     {?VD("update_from_ejson updates the fields but ignores admin and public_key"),
+      fun() ->
+              KeyData = public_key_data(),
+              EJ = {[{<<"name">>, <<"a_name">>}, {<<"validator">>, true},
+                     {<<"public_key">>, KeyData}, {<<"admin">>, true}]},
+              OriginalClient = #chef_client{server_api_version = Version},
+              NewClient = chef_client:update_from_ejson(OriginalClient, EJ),
+              ?assertMatch(#chef_client{server_api_version = Version,
+                                        name = <<"a_name">>,
+                                        validator = true,
+                                        admin = false, % we default false in the record
+                                        pubkey_version = undefined,
+                                        public_key = undefined}, NewClient)
+      end}
+    ].
+
+update_from_ejson_common_tests(Version) ->
+    [
+     {?VD("update_from_ejson updates the fields when key is not set"),
+      fun() ->
+              EJ = {[{<<"name">>, <<"a_name">>}, {<<"validator">>, true}]},
+              OriginalClient = #chef_client{server_api_version = Version},
+              NewClient = chef_client:update_from_ejson(OriginalClient, EJ),
+              ?assertMatch(#chef_client{server_api_version = Version,
+                                        name = <<"a_name">>,
+                                        validator = true}, NewClient)
+      end}
+     ].
+
+update_from_ejson_deprecated_tests(Version) ->
+    [
+     {?VDD("update_from_ejson updates the fields when key is not set"),
+      fun() ->
+              EJ = {[{<<"name">>, <<"a_name">>}, {<<"validator">>, true}]},
+              OriginalClient = #chef_client{server_api_version = Version},
+              NewClient = chef_client:update_from_ejson(OriginalClient, EJ),
+              ?assertMatch(#chef_client{server_api_version = Version,
+                                        name = <<"a_name">>,
+                                        validator = true}, NewClient)
+      end},
+     {?VDD("update_from_ejson updates the fields including public key when key is set"),
+      fun() ->
+              KeyData = public_key_data(),
+              EJ = {[{<<"name">>, <<"a_name">>}, {<<"validator">>, true},
+                     {<<"public_key">>, KeyData}]},
+              OriginalClient = #chef_client{server_api_version = Version},
+              NewClient = chef_client:update_from_ejson(OriginalClient, EJ),
+              ?assertMatch(#chef_client{server_api_version = Version,
+                                        name = <<"a_name">>,
+                                        validator = true,
+                                        pubkey_version = ?KEY_VERSION,
+                                        public_key = KeyData}, NewClient)
+      end}
+    ].
+
+
 %% remove trailing whitespace from a string
 chomp(In) ->
     re:replace(In, "\\s+$", "", [{return, binary}]).
@@ -46,98 +330,3 @@ public_key_data() ->
 cert_data() ->
     {ok, Bin} = file:read_file("../test/cert.pem"),
     chomp(Bin).
-
-assemble_client_ejson_test_() ->
-    [{"obtain expected EJSON",
-      fun() ->
-              Client = #chef_client{server_api_version = ?API_MIN_VER,
-                                    name = <<"alice">>,
-                                    admin = true,
-                                    validator = false,
-                                    public_key = public_key_data()},
-              {GotList} = chef_client:assemble_client_ejson(Client, <<"ponyville">>),
-              FilteredList = chomp_key_in_json_list(GotList),
-              ExpectedData = [{<<"json_class">>, <<"Chef::ApiClient">>},
-                              {<<"chef_type">>, <<"client">>},
-                              {<<"public_key">>, public_key_data()},
-                              {<<"validator">>, false},
-                              {<<"name">>, <<"alice">>},
-                              {<<"clientname">>, <<"alice">>},
-                              {<<"orgname">>, <<"ponyville">>}
-                             ],
-              ?assertEqual(lists:sort(ExpectedData), lists:sort(FilteredList))
-      end},
-     {"converts certificate to public key",
-      fun() ->
-              Client = #chef_client{server_api_version = ?API_MIN_VER,
-                                    name = <<"alice">>,
-                                    admin = true,
-                                    validator = false,
-                                    public_key = cert_data()},
-              {GotList} = chef_client:assemble_client_ejson(Client, <<"ponyville">>),
-              FilteredList = chomp_key_in_json_list(GotList),
-              ExpectedData = [{<<"json_class">>, <<"Chef::ApiClient">>},
-                              {<<"chef_type">>, <<"client">>},
-                              {<<"public_key">>, public_key_data()},
-                              {<<"validator">>, false},
-                              {<<"name">>, <<"alice">>},
-                              {<<"clientname">>, <<"alice">>},
-                              {<<"orgname">>, <<"ponyville">>}
-                             ],
-              ?assertEqual(lists:sort(ExpectedData), lists:sort(FilteredList))
-      end}
-    ].
-
-
-
-parse_binary_json_test_() ->
-    [{"Error thrown on mismatched names",
-      fun() ->
-          Body = <<"{\"name\":\"name\",\"clientname\":\"notname\"}">>,
-          ?assertThrow({client_name_mismatch}, chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>))
-      end
-     },
-     {"Can create with only name",
-      fun() ->
-          Body = <<"{\"name\":\"name\"}">>,
-          {ok, Client} = chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>),
-          Name = ej:get({<<"name">>}, Client),
-          ClientName = ej:get({<<"clientname">>}, Client),
-          ?assertEqual(Name, ClientName)
-      end
-     },
-     {"Can create with only clientname",
-      fun() ->
-          Body = <<"{\"clientname\":\"name\"}">>,
-          {ok, Client} = chef_client:parse_binary_json(?API_MIN_VER, Body, <<"name">>),
-          Name = ej:get({<<"name">>}, Client),
-          ClientName = ej:get({<<"clientname">>}, Client),
-          ?assertEqual(Name, ClientName)
-      end
-     },
-     {"Error thrown with no name or clientname",
-      fun() ->
-          Body = <<"{\"validator\":false}">>,
-          ?assertThrow({both_missing, <<"name">>, <<"clientname">>},
-                       chef_client:parse_binary_json(?API_MIN_VER, Body, undefined))
-      end
-     },
-     {"Error thrown with bad name",
-      fun() ->
-          Body = <<"{\"name\":\"bad~name\"}">>,
-          ?assertThrow({bad_client_name, <<"bad~name">>,
-                        <<"Malformed client name.  Must be A-Z, a-z, 0-9, _, -, or .">>},
-                       chef_client:parse_binary_json(?API_MIN_VER, Body, <<"bad~name">>))
-      end
-     }
-    ].
-
-
-new_record_test() ->
-    OrgId = <<"12345678123456781234567812345678">>,
-    AuthzId = <<"00000000000000000000000011111111">>,
-    ClientData = {[{<<"name">>, <<"my-client">>}, {<<"alpha">>, <<"bravo">>}]},
-    Client = chef_client:new_record(?API_MIN_VER, OrgId, AuthzId, ClientData),
-    ?assertMatch(#chef_client{}, Client),
-    %% TODO: validate more fields?
-    ?assertEqual(<<"my-client">>, chef_client:name(Client)).

--- a/apps/chef_objects/test/chef_key_base_tests.erl
+++ b/apps/chef_objects/test/chef_key_base_tests.erl
@@ -54,6 +54,97 @@ set_key_pair_test_() ->
                   ?_assertEqual(DataForType(Type), ej:get({KeyForType(Type)}, Got)),
                   ?_assertEqual(undefined, ej:get({NotKeyForType(Type)}, Got))]
              end
-             || Type <- [key, cert] ],
+             || Type <- [key, cert] ] ++
+            [
+               {"public key is set but private key is not when private key is not provided and public is",
+                fun() ->
+                        KeyData = public_key_data(),
+                        Got = chef_key_base:set_key_pair(Ejson, {public_key, KeyData}, {private_key, undefined}),
+                        ?assertEqual(undefined, ej:get({<<"private_key">>}, Got)),
+                        ?assertEqual(KeyData, ej:get({<<"public_key">>}, Got))
+
+
+                end}],
+
     lists:flatten(Tests).
+
+set_public_key_test_() ->
+    EJ = {[]},
+    KeyData = public_key_data(),
+    [{"public key is set in ejson when provided",
+      fun() ->
+        NewEJ = chef_key_base:set_public_key(EJ, KeyData),
+        ?assertEqual(KeyData, ej:get({<<"public_key">>}, NewEJ) )
+      end},
+     {"public key is null in ejson when null is set",
+      fun() ->
+        NewEJ = chef_key_base:set_public_key(EJ, null),
+        ?assertEqual(null, ej:get({<<"public_key">>}, NewEJ))
+      end},
+     {"public key is undefined and cert is set in ejson when cert is provided",
+      fun() ->
+        CertData = cert_data(),
+        NewEJ = chef_key_base:set_public_key(EJ, CertData),
+        ?assertEqual(CertData, ej:get({<<"certificate">>}, NewEJ)),
+        ?assertEqual(undefined, ej:get({<<"public_key">>}, NewEJ))
+      end}
+    ].
+
+maybe_generate_key_pair_test_() ->
+    {setup,
+     fun test_utils:keygen_setup/0,
+     fun test_utils:keygen_cleanup/1,
+     [
+      {"when called with create_key true, a key pair is generated and passed into the continuation fun",
+      fun() ->
+        Echo = fun(Data) -> Data end,
+        {Pub, Priv} = chef_key_base:maybe_generate_key_pair({[{<<"create_key">>, true}]}, Echo),
+        ?assertEqual(true, is_binary(Pub)),
+        ?assertEqual(true, is_binary(Priv))
+
+      end},
+      {"when called with create_key false and a public key, the key is not generated and the public key is passed into the continuation fun",
+      fun() ->
+        Echo = fun(Data) -> Data end,
+        Result = chef_key_base:maybe_generate_key_pair({[{<<"create_key">>, false},{<<"public_key">>, <<"pubkey">>}]},
+                                                      Echo),
+        ?assertMatch({<<"pubkey">>, undefined}, Result)
+
+      end}
+     ]
+    }.
+
+maybe_generate_key_pair_deprecated_test_() ->
+    KeyData = public_key_data(),
+    {setup,
+     fun test_utils:keygen_setup/0,
+     fun test_utils:keygen_cleanup/1,
+     [{"when private_key is specified, the response contains a public and private key",
+       fun() ->
+         EJ = {[{<<"private_key">>, true}]},
+         NewEJ = chef_key_base:maybe_generate_key_pair(EJ),
+         ?assertEqual(true, is_binary(ej:get({<<"private_key">>}, NewEJ))),
+         ?assertEqual(true, is_binary(ej:get({<<"public_key">>}, NewEJ)))
+       end},
+      {"when a valid public key is specified, the response is not modified.",
+       fun() ->
+         EJ = {[{<<"public_key">>, KeyData}]},
+         NewEJ = chef_key_base:maybe_generate_key_pair(EJ),
+         ?assertMatch(EJ,  NewEJ)
+       end},
+      {"when a valid public_key is specified alongside private_key:true, the response contains a new public and private key",
+       fun() ->
+
+         EJ = {[{<<"public_key">>, KeyData},
+                {<<"private_key">>, true}]},
+         NewEJ = chef_key_base:maybe_generate_key_pair(EJ),
+         ?assertEqual(true, is_binary(ej:get({<<"private_key">>}, NewEJ))),
+         ?assertEqual(true, is_binary(ej:get({<<"public_key">>}, NewEJ))),
+         ?assertNotEqual(KeyData, ej:get({<<"public_key">>}, NewEJ))
+
+       end}
+     ]}.
+    %validate_public_key_fields_test_() ->
+
+
 

--- a/apps/chef_objects/test/chef_user_tests.erl
+++ b/apps/chef_objects/test/chef_user_tests.erl
@@ -26,83 +26,194 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
+-define(VD(D), test_utils:versioned_desc(Version,D)).
+-define(VDD(D), test_utils:versioned_desc(Version, iolist_to_binary(["[deprecated] ", D]))).
+
 assemble_user_ejson_test_() ->
     {setup,
      fun test_utils:bcrypt_setup/0,
      fun test_utils:bcrypt_cleanup/1,
-    [{"obtain expected EJSON",
+     test_utils:make_all_versions_tests(fun assemble_user_ejson_tests/1) }.
+
+assemble_user_ejson_tests(Version) ->
+    [{?VD("obtain expected EJSON"),
       fun() ->
-              User = make_valid_user_record(),
+              User = make_valid_user_record(Version),
               {GotList} = chef_user:assemble_user_ejson(User, ?OSC_ORG_NAME),
-              ExpectedData = base_user_record_as_ejson(),
+              ExpectedData = base_user_record_as_ejson(Version),
               ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
       end},
-     {"obtain expected EJSON for valid serialized_data",
+     {?VD("obtain expected EJSON for valid serialized_data"),
       fun() ->
               % Rather than fight with escaping, quotes, etc, we'll just make some valid ejson the eas yway
-              User = make_valid_user_record(chef_json:encode({persisted_serializable_fields()})),
+              User = make_valid_user_record(chef_json:encode({persisted_serializable_fields()}), Version),
               {GotList} = chef_user:assemble_user_ejson(User, ?OSC_ORG_NAME),
-              ExpectedData = base_user_record_as_ejson() ++  persisted_serializable_fields(),
+              ExpectedData = base_user_record_as_ejson(Version) ++  persisted_serializable_fields(),
               ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
       end},
-     {"silently ignores unknown field values found in serialized_data",
+     {?VD("silently ignores unknown field values found in serialized_data"),
       fun() ->
               % Rather than fight with escaping, quotes, etc, we'll just make some valid ejson the eas yway
               UserWithUnknownPersistedData = persisted_serializable_fields() ++
                                              [ {<<"badfield1">>, <<"anyvalue">>},
                                                {<<"badfield2">>, <<"anyvalue">>}],
 
-              User = make_valid_user_record(chef_json:encode({UserWithUnknownPersistedData})),
+              User = make_valid_user_record(chef_json:encode({UserWithUnknownPersistedData}), Version),
               {GotList} = chef_user:assemble_user_ejson(User, ?OSC_ORG_NAME),
-              ExpectedData = base_user_record_as_ejson() ++  persisted_serializable_fields(),
+              ExpectedData = base_user_record_as_ejson(Version) ++  persisted_serializable_fields(),
+              ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
+      end}
+    ].
+
+assemble_user_ejson_non_deprecated_test_() ->
+    {setup,
+     fun test_utils:bcrypt_setup/0,
+     fun test_utils:bcrypt_cleanup/1,
+     test_utils:make_non_deprecated_tests(fun assemble_user_ejson_non_deprecated_tests/1) }.
+
+assemble_user_ejson_non_deprecated_tests(Version)->
+    {setup,
+     fun test_utils:bcrypt_setup/0,
+     fun test_utils:bcrypt_cleanup/1,
+     [{?VD("obtain expected EJSON"),
+       fun() ->
+               User = make_valid_user_record(Version),
+               {GotList} = chef_user:assemble_user_ejson(User, ?OSC_ORG_NAME),
+               ExpectedData = base_user_record_as_ejson(Version),
+               ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
+       end}
+     ]}.
+
+assemble_user_ejson_deprecated_test_() ->
+    test_utils:make_deprecated_tests(fun assemble_user_ejson_deprecated_tests/1).
+assemble_user_ejson_deprecated_tests(Version) ->
+    {setup,
+     fun test_utils:bcrypt_setup/0,
+     fun test_utils:bcrypt_cleanup/1,
+    [{?VDD("obtain expected EJSON"),
+      fun() ->
+              User = make_valid_user_record(Version),
+              {GotList} = chef_user:assemble_user_ejson(User, ?OSC_ORG_NAME),
+              ExpectedData = base_user_record_as_ejson(Version),
+              ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
+      end},
+     {?VDD("obtain expected EJSON for valid serialized_data"),
+      fun() ->
+              % Rather than fight with escaping, quotes, etc, we'll just make some valid ejson the eas yway
+              User = make_valid_user_record(chef_json:encode({persisted_serializable_fields()}), Version),
+              {GotList} = chef_user:assemble_user_ejson(User, ?OSC_ORG_NAME),
+              ExpectedData = base_user_record_as_ejson(Version) ++  persisted_serializable_fields(),
+              ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
+      end},
+     {?VDD("silently ignores unknown field values found in serialized_data"),
+      fun() ->
+              % Rather than fight with escaping, quotes, etc, we'll just make some valid ejson the eas yway
+              UserWithUnknownPersistedData = persisted_serializable_fields() ++
+                                             [ {<<"badfield1">>, <<"anyvalue">>},
+                                               {<<"badfield2">>, <<"anyvalue">>}],
+
+              User = make_valid_user_record(chef_json:encode({UserWithUnknownPersistedData}), Version),
+              {GotList} = chef_user:assemble_user_ejson(User, ?OSC_ORG_NAME),
+              ExpectedData = base_user_record_as_ejson(Version) ++  persisted_serializable_fields(),
               ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
       end}
     ]}.
 
+parse_binary_json_deprecated_test_() ->
+    test_utils:make_deprecated_tests(fun parse_binary_json_deprecated_tests/1).
+
+parse_binary_json_deprecated_tests(Version) ->
+    [{?VDD("a null public_key is removed for create"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, null}],
+              {ok, Got} = chef_user:parse_binary_json(Version, chef_json:encode({UserEJson}), create, undefined),
+              ?assertEqual(undefined, ej:get({"public_key"}, Got))
+      end},
+     {?VDD("a null public_key is removed for update"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, null}],
+              {ok, Got} = chef_user:parse_binary_json(Version, chef_json:encode({UserEJson}), update, #chef_user{}),
+              ?assertEqual(undefined, ej:get({"public_key"}, Got))
+      end},
+
+     {?VDD("a valid public_key is preserved for both create and update"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, public_key_data()}],
+              Body = chef_json:encode({UserEJson}),
+              {ok, Got1} = chef_user:parse_binary_json(Version, Body, create, undefined),
+              ?assertEqual(public_key_data(), ej:get({"public_key"}, Got1)),
+              {ok, Got2} = chef_user:parse_binary_json(Version, Body, update, #chef_user{}),
+              ?assertEqual(public_key_data(), ej:get({"public_key"}, Got2))
+      end},
+
+     {?VDD("A valid public key is removed when private_key = true"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, public_key_data()},
+                                                                 {<<"private_key">>, true}],
+              Body = chef_json:encode({UserEJson}),
+              {ok, Got1} = chef_user:parse_binary_json(Version, Body, create, undefined),
+              ?assertEqual(undefined, ej:get({"public_key"}, Got1))
+      end
+     },
+     {?VDD("An invalid public key is removed from the object when private_key = true (key not validated)"),
+      fun() ->
+             UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, <<"a bad key">>},
+                                                                {<<"private_key">>, true}],
+              Body = chef_json:encode({UserEJson}),
+
+              {ok, Got1} = chef_user:parse_binary_json(Version, Body, create, undefined),
+              ?assertEqual(undefined, ej:get({"public_key"}, Got1))
+      end
+    }
+    ].
+
 parse_binary_json_test_() ->
-    [{"Can create user when all required fields are present",
+    test_utils:make_all_versions_tests(fun parse_binary_json_tests/1).
+
+parse_binary_json_tests(Version) ->
+    [{?VD("Can create user when all required fields are present"),
       fun() ->
                 MinValid = make_min_valid_create_user_ejson(),
                 UserJson = chef_json:encode({MinValid}),
-                {ok, {GotData}} = chef_user:parse_binary_json(?API_MIN_VER, UserJson, create, undefined),
+                {ok, {GotData}} = chef_user:parse_binary_json(Version, UserJson, create, undefined),
                 ?assertEqual(lists:sort(MinValid), lists:sort(GotData))
       end
      },
-     {"Can create user when external auth uid is present",
+     {?VD("Can create user when external auth uid is present"),
       fun() ->
                 MinValid = make_external_auth_create_user_ejson(),
                 UserJson = chef_json:encode({MinValid}),
-                {ok, {GotData}} = chef_user:parse_binary_json(?API_MIN_VER, UserJson, create, undefined),
+                {ok, {GotData}} = chef_user:parse_binary_json(Version, UserJson, create, undefined),
                 ?assertEqual(lists:sort(MinValid), lists:sort(GotData))
       end
      },
-     {"Can not create with only name and password",
+     {?VD("Can not create with only name and password"),
       fun() ->
               UserEjson = chef_json:encode({[
                                              {<<"name">>, <<"bob">>},
                                              {<<"password">>, <<"top secret 123456">>}
                                             ]}),
-              ?assertThrow(#ej_invalid{}, chef_user:parse_binary_json(?API_MIN_VER, UserEjson, create, undefined))
+              ?assertThrow(#ej_invalid{}, chef_user:parse_binary_json(Version, UserEjson, create, undefined))
       end
      },
-     {"Valid email must be provided",
+     {?VD("Valid email must be provided"),
       fun() ->
                     UserEJson = make_min_valid_create_user_ejson(),
                     UserEJson2 = ej:set({<<"email">>}, {UserEJson}, <<"jo my @ bob.com">>),
                     UserJson = chef_json:encode(UserEJson2),
                     ?assertThrow(#ej_invalid{type = fun_match},
-                                 chef_user:parse_binary_json(?API_MIN_VER, UserJson, create, undefined))
+                                 chef_user:parse_binary_json(Version, UserJson, create, undefined))
       end},
-     {"required fields must be provided", generator,
+     {?VD("required fields must be provided"), generator,
       fun() ->
               NukeFields = [<<"email">>, <<"password">>, <<"username">>, <<"display_name">>],
               UserEJson = {make_min_valid_create_user_ejson()},
 
               [ ?_assertThrow(#ej_invalid{type = missing, key = Key},
-                             chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode(ej:delete({Key}, UserEJson)), create, undefined))
+                             chef_user:parse_binary_json(Version, chef_json:encode(ej:delete({Key}, UserEJson)), create, undefined))
                              || Key  <- NukeFields]
       end},
-     {"Properly formed emails are accepted", generator,
+     {?VD("Properly formed emails are accepted"), generator,
       fun() ->
               GoodEmail = [<<"me@here.com">>, <<"me@here.com.com.au.zebra">>,
                            <<"me+you@here.com">>,
@@ -110,67 +221,43 @@ parse_binary_json_test_() ->
                            <<"me.you@here.com">>],
               UserEJson = {make_min_valid_create_user_ejson()},
                     [ ?_assertMatch({ok, _},
-                             chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode(ej:set({<<"email">>}, UserEJson, E)), create, undefined))
+                             chef_user:parse_binary_json(Version, chef_json:encode(ej:set({<<"email">>}, UserEJson, E)), create, undefined))
                              || E <- GoodEmail]
       end},
-     {"Improperly formed emails are rejected", generator,
+     {?VD("Improperly formed emails are rejected"), generator,
       fun() ->
               BadEmail = [<<"short">>, <<"shorter@short">>,  <<"short\\andinvalid@somewhre.com">>,
                           <<"spaces are not valid@either.com">>, <<"\"spaces are not valid\"@either.com">>],
               UserEJson = {make_min_valid_create_user_ejson()},
                     [ ?_assertThrow(#ej_invalid{key = <<"email">>},
-                              chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode(ej:set({<<"email">>}, UserEJson, E)), create, undefined))
+                              chef_user:parse_binary_json(Version, chef_json:encode(ej:set({<<"email">>}, UserEJson, E)), create, undefined))
                              || E <- BadEmail]
       end},
-     {"Password must be valid", generator,
+     {?VD("Password must be valid"), generator,
       fun() ->
               BadPass = [<<"short">>, 123, [<<"longenoughbutinalist">>], {[]}, true, null],
               UserEJson = {make_min_valid_create_user_ejson()},
                     [ ?_assertThrow(#ej_invalid{key = <<"password">>},
-                             chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode(ej:set({<<"password">>}, UserEJson, P)), create, undefined))
+                             chef_user:parse_binary_json(Version, chef_json:encode(ej:set({<<"password">>}, UserEJson, P)), create, undefined))
                || P<- BadPass]
       end},
-     {"Accepts name instead of username",
+     {?VD("Accepts name instead of username"),
       fun() ->
               UserEJson = {make_min_valid_create_user_ejson()},
               UserEJson1 = ej:delete({<<"username">>}, UserEJson),
               UserEJson2 = ej:set({<<"name">>}, UserEJson1, "validname"),
-              ?_assertMatch({ok, _}, chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode(UserEJson2), create, undefined))
+              ?_assertMatch({ok, _}, chef_user:parse_binary_json(Version, chef_json:encode(UserEJson2), create, undefined))
       end
      },
-     {"Error thrown with bad name",
+     {?VD("Error thrown with bad name"),
       fun() ->
               UserEJson = {make_min_valid_create_user_ejson()},
               Body = ej:set({<<"username">>}, UserEJson, <<"bad~name">>),
               ?assertThrow(#ej_invalid{key = <<"username">>},
-                           chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode(Body), update, #chef_user{}))
+                           chef_user:parse_binary_json(Version, chef_json:encode(Body), update, #chef_user{}))
       end
      },
-     {"a null public_key is removed for create",
-      fun() ->
-              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, null}],
-              {ok, Got} = chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode({UserEJson}), create, undefined),
-              ?assertEqual(undefined, ej:get({"public_key"}, Got))
-      end},
-
-     {"a null public_key is removed for update",
-      fun() ->
-              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, null}],
-              {ok, Got} = chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode({UserEJson}), update, #chef_user{}),
-              ?assertEqual(undefined, ej:get({"public_key"}, Got))
-      end},
-
-     {"a valid public_key is preserved for both create and update",
-      fun() ->
-              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, public_key_data()}],
-              Body = chef_json:encode({UserEJson}),
-              {ok, Got1} = chef_user:parse_binary_json(?API_MIN_VER, Body, create, undefined),
-              ?assertEqual(public_key_data(), ej:get({"public_key"}, Got1)),
-              {ok, Got2} = chef_user:parse_binary_json(?API_MIN_VER, Body, update, #chef_user{}),
-              ?assertEqual(public_key_data(), ej:get({"public_key"}, Got2))
-      end},
-
-     {"Errors thrown for invalid public_key data ", generator,
+     {?VD("Errors thrown for invalid public_key data on create "), generator,
       fun() ->
               MungedKey = re:replace(public_key_data(), "A", "2",
                                      [{return, binary}, global]),
@@ -178,38 +265,87 @@ parse_binary_json_test_() ->
                          113, [public_key_data()], {[]}],
               Body = { make_min_valid_create_user_ejson() },
              [ ?_assertThrow(#ej_invalid{key = <<"public_key">>},
-                             chef_user:parse_binary_json(?API_MIN_VER, chef_json:encode(ej:set({<<"public_key">>}, Body, Bad)), update, #chef_user{}))
+                             chef_user:parse_binary_json(Version, chef_json:encode(ej:set({<<"public_key">>}, Body, Bad)),
+                                                         create, undefined))
                 || Bad <- BadKeys ]
-      end},
-     {"A valid public key is removed when private_key = true",
-      fun() ->
-              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, public_key_data()},
-                                                                 {<<"private_key">>, true}],
-              Body = chef_json:encode({UserEJson}),
-              {ok, Got1} = chef_user:parse_binary_json(?API_MIN_VER, Body, create, undefined),
-              ?assertEqual(undefined, ej:get({"public_key"}, Got1))
-      end
-     },
-    {"An invalid public key is removed from the object when private_key = true (key not validated)",
-      fun() ->
-             UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, <<"a bad key">>},
-                                                                {<<"private_key">>, true}],
-              Body = chef_json:encode({UserEJson}),
-
-              {ok, Got1} = chef_user:parse_binary_json(?API_MIN_VER, Body, create, undefined),
-              ?assertEqual(undefined, ej:get({"public_key"}, Got1))
-      end
-    }
+      end}
     ].
 
+parse_binary_json_non_deprecated_test_() ->
+    test_utils:make_non_deprecated_tests(fun parse_binary_json_non_deprecated_tests /1).
+
+parse_binary_json_non_deprecated_tests(Version) ->
+    [{?VD("Public key is rejected as a field for update, even when valid"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, public_key_data()}],
+              Body = chef_json:encode({UserEJson}),
+              ?assertThrow(key_management_not_supported,
+                           chef_user:parse_binary_json(Version, Body, update, #chef_user{}))
+      end},
+     {?VD("create_key is rejected as a field for update"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"create_key">>, true}],
+              Body = chef_json:encode({UserEJson}),
+              ?assertThrow(key_management_not_supported,
+                           chef_user:parse_binary_json(Version, Body, update, #chef_user{}))
+      end},
+     {?VD("private_key is rejected as a field for create"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"private_key">>, true}],
+              Body = chef_json:encode({UserEJson}),
+              ?assertThrow(private_key_field_not_supported,
+                           chef_user:parse_binary_json(Version, Body, create, undefined))
+      end},
+     {?VD("private_key is rejected as a field for update"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"private_key">>, true}],
+              Body = chef_json:encode({UserEJson}),
+              ?assertThrow(private_key_field_not_supported,
+                           chef_user:parse_binary_json(Version, Body, update, #chef_user{}))
+      end},
+    {?VD("When both create_key and public_key are specified on create, an error is thrown"),
+      fun() ->
+             UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, public_key_data()},
+                                                                {<<"create_key">>, true}],
+              Body = chef_json:encode({UserEJson}),
+
+              ?assertThrow(create_and_pubkey_specified,
+                           chef_user:parse_binary_json(Version, Body, create, undefined))
+
+      end},
+    {?VD("When neither create_key and public_key are specified on create, it is permitted"),
+      fun() ->
+             UserEJson = make_min_valid_create_user_ejson(),
+              Body = chef_json:encode({UserEJson}),
+              ?assertMatch({ok, _}, chef_user:parse_binary_json(Version, Body, create, undefined))
+
+      end},
+    {?VD("When create_key = false and public_key are specified on create, it is permitted"),
+      fun() ->
+             UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, public_key_data()},
+                                                                {<<"create_key">>, false}],
+              Body = chef_json:encode({UserEJson}),
+              ?assertMatch({ok, _}, chef_user:parse_binary_json(Version, Body, create, undefined))
+
+      end},
+     {?VD("a null public_key is rejected for create"),
+      fun() ->
+              UserEJson = make_min_valid_create_user_ejson() ++ [{<<"public_key">>, null}],
+              ?assertThrow(#ej_invalid{key = <<"public_key">>},
+                             chef_user:parse_binary_json(Version, chef_json:encode({UserEJson}), create, undefined))
+      end}
+    ].
 
 update_record_test_() ->
+    test_utils:make_all_versions_tests(fun update_record_tests/1).
+
+update_record_tests(Version) ->
     {setup,
      fun() ->
         test_utils:bcrypt_setup(),
-        SerializedAsEJson = {base_user_record_as_ejson() ++
+        SerializedAsEJson = {base_user_record_as_ejson(Version) ++
                              persisted_serializable_fields() },
-        make_valid_user_record(chef_json:encode(SerializedAsEJson))
+        make_valid_user_record(chef_json:encode(SerializedAsEJson), Version)
      end,
      fun test_utils:bcrypt_cleanup/1,
      fun(User) ->
@@ -223,20 +359,21 @@ update_record_test_() ->
         UpdatePassword = {[ {<<"password">>, <<"a new password">>} ]},
         ExtAuthUpdate = [{<<"external_authentication_uid">>, <<"bob">>},
                           {<<"recovery_authentication_enabled">>, true}],
-        SerializedObject = chef_json:encode({base_user_record_as_ejson()
+        SerializedObject = chef_json:encode({base_user_record_as_ejson(Version)
                                              ++ persisted_serializable_fields()}),
-        UserWithExtAuthData = make_valid_user_record_with_external_auth(SerializedObject),
+        UserWithExtAuthData = make_valid_user_record_with_external_auth(SerializedObject, Version),
         User1 = chef_user:update_from_ejson(User, UpdateAsEJson),
         User2 = chef_user:update_from_ejson(User, UpdatePassword),
         User3 = chef_user:update_from_ejson(User, ExtAuthUpdate),
         User4 = chef_user:update_from_ejson(UserWithExtAuthData, UpdateAsEJson),
-        [{"changed values are changed",
+        [
+        {?VD("changed values are changed"),
            fun() ->
                 ?assertEqual(<<"new_email@somewhere.com">>, User1#chef_user.email),
                 ?assertEqual(<<"martha">>, User1#chef_user.username)
            end
         },
-        {"nulled serialized values are deleted from the serialized object",
+        {?VD("nulled serialized values are deleted from the serialized object"),
            fun() ->
                 % implicit test here that data has been serialized.
                 Data = chef_json:decode(User1#chef_user.serialized_object),
@@ -244,56 +381,56 @@ update_record_test_() ->
                 ?assertEqual(ej:get({<<"twitter_account">>}, Data), undefined)
            end
         },
-        {"serialized values specified as atom undefined are ignored in the serialized object",
+        {?VD("serialized values specified as atom undefined are ignored in the serialized object"),
            fun() ->
                 % implicit test here that data has been serialized.
                 Data = chef_json:decode(User1#chef_user.serialized_object),
                 ?assertEqual(ej:get({<<"city">>}, Data), <<"hereville">>)
            end
         },
-        {"updated serialized values are updated within the serialized object",
+        {?VD("updated serialized values are updated within the serialized object"),
            fun() ->
                 % implicit test here that data has been serialized.
                 Data = chef_json:decode(User1#chef_user.serialized_object),
                 ?assertEqual(ej:get({<<"display_name">>}, Data), <<"martha stewart pony">>)
            end
         },
-        {"garbage values are not retained",
+        {?VD("garbage values are not retained"),
            fun() ->
                 Data = chef_json:decode(User1#chef_user.serialized_object),
                 ?assertEqual(ej:get({<<"garbage">>}, Data), undefined)
            end
         },
-        {"unchanged password has no side effects",
+        {?VD("unchanged password has no side effects"),
            fun() ->
                 ?assertEqual(User#chef_user.hashed_password, User#chef_user.hashed_password),
                 ?assertEqual(User#chef_user.salt, User#chef_user.salt)
            end
         },
-        {"password updates related fields",
+        {?VD("password updates related fields"),
            fun() ->
                 ?assertNotEqual(User#chef_user.hashed_password, User2#chef_user.hashed_password),
                 ?assertNotEqual(User#chef_user.salt, User2#chef_user.salt)
            end
         },
-        {"external authentication data is not when it should not be",
+        {?VD("external authentication data is not when it should not be"),
            fun() ->
                 ?assertEqual(null, User1#chef_user.external_authentication_uid),
                 ?assertEqual(false, User1#chef_user.recovery_authentication_enabled)
            end
         },
-        {"external authentication data is not updated when it should not be",
+        {?VD("external authentication data is not updated when it should not be"),
            fun() ->
                 ?assertEqual(<<"amoney">>, User4#chef_user.external_authentication_uid),
                 ?assertEqual(true, User4#chef_user.recovery_authentication_enabled)
            end
         },
-         {"external authentication data is updated when it should be",
-           fun() ->
-                ?assertEqual(<<"bob">>, User3#chef_user.external_authentication_uid),
-                ?assertEqual(true, User3#chef_user.recovery_authentication_enabled)
-           end
-        }]
+        {?VD("external authentication data is updated when it should be"),
+          fun() ->
+               ?assertEqual(<<"bob">>, User3#chef_user.external_authentication_uid),
+               ?assertEqual(true, User3#chef_user.recovery_authentication_enabled)
+          end}
+         ]
       end
     }.
 
@@ -323,11 +460,12 @@ new_record_no_password_test() ->
 public_key_data() ->
     <<"-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCyVPW9YXa5PR0rgEW1updSxygB\nwmVpDnHurgQ7/gbh+PmY49EZsfrZSbKgSKy+rxdsVoSoU+krYtHvYIwVfr2tk0FP\nnhAWJaFH654KpuCNG6x6iMLtzGO1Ma/VzHnFqoOeSCKHXDhmHwJAjGDTPAgCJQiI\neau6cDNJRiJ7j0/xBwIDAQAB\n-----END PUBLIC KEY-----">>.
 
-make_valid_user_record() ->
-    make_valid_user_record(<<"{}">>).
-make_valid_user_record(SerializedObject) ->
+make_valid_user_record(Version) ->
+    make_valid_user_record(<<"{}">>, Version).
+make_valid_user_record(SerializedObject, Version) ->
     {HashedPassword, Salt ,Type} = chef_password:encrypt("a password"),
-    #chef_user{username = <<"alice">>,
+    #chef_user{server_api_version = Version,
+               username = <<"alice">>,
                email = <<"test@test.com">>,
                authz_id = <<"1234">>,
                public_key = public_key_data(),
@@ -335,9 +473,10 @@ make_valid_user_record(SerializedObject) ->
                salt = Salt,
                hash_type = Type,
                serialized_object = SerializedObject}.
-make_valid_user_record_with_external_auth(SerializedObject) ->
+make_valid_user_record_with_external_auth(SerializedObject, Version) ->
     {HashedPassword, Salt ,Type} = chef_password:encrypt("a password"),
-    #chef_user{username = <<"alice">>,
+    #chef_user{server_api_version = Version,
+               username = <<"alice">>,
                external_authentication_uid = <<"amoney">>,
                recovery_authentication_enabled = true,
                email = <<"test@test.com">>,
@@ -361,9 +500,12 @@ make_external_auth_create_user_ejson() ->
      {<<"external_authentication_uid">>, <<"alice">>},
      {<<"display_name">>, <<"alice bobson">>}].
 
-base_user_record_as_ejson() ->
+base_user_record_as_ejson(?API_v0) ->
     [{<<"public_key">>, public_key_data()},
      {<<"username">>, <<"alice">>},
+     {<<"email">>, <<"test@test.com">>}];
+base_user_record_as_ejson(_Version) ->
+    [{<<"username">>, <<"alice">>},
      {<<"email">>, <<"test@test.com">>}].
 
 

--- a/apps/oc_chef_wm/itest/oc_chef_wm_keys_SUITE.erl
+++ b/apps/oc_chef_wm/itest/oc_chef_wm_keys_SUITE.erl
@@ -742,8 +742,8 @@ new_key_ejson(Config, Name, Expiration) ->
     new_key_ejson(Config, Name, Expiration, pubkey).
 new_key_ejson(_Config, Name, Expiration, create_key) ->
     {[{<<"name">>, Name}, {<<"create_key">>, true}, {<<"expiration_date">>, Expiration}]};
-new_key_ejson(Config, Name, Expiration, PubKey) ->
-    PubKey = proplists:get_value(PubKey, Config),
+new_key_ejson(Config, Name, Expiration, KeyName) ->
+    PubKey = proplists:get_value(KeyName, Config),
     {[{<<"name">>, Name}, {<<"public_key">>, PubKey}, {<<"expiration_date">>, Expiration}]}.
 
 has_well_formed_public_key(Config, EJ) ->

--- a/apps/oc_chef_wm/src/chef_wm_malformed.erl
+++ b/apps/oc_chef_wm/src/chef_wm_malformed.erl
@@ -99,15 +99,19 @@ malformed_request_message({bad_run_lists, {Field, _Value}}, _Req, _State) ->
 malformed_request_message(invalid_num_versions, _Req, _State) ->
     {[{<<"error">>, [<<"You have requested an invalid number of versions (x >= 0 || 'all')">>]}]};
 
-%% This is used by some custom validation in environments that may (or may not!) be pulled up into ej:valid validations
+%% This is used by some custom validation for validation patterns that can't be expressed well as ej:valid rules
 malformed_request_message({invalid_key, Key}, _Req, _State) ->
     error_envelope([<<"Invalid key ">>, Key, <<" in request body">>]);
-
-
 malformed_request_message(create_or_pubkey_missing, _Req, _State) ->
     error_envelope([<<"You must either provide a valid value for 'public_key', or specify 'create_key': true">>]);
 malformed_request_message(create_and_pubkey_specified, _Req, _State) ->
     error_envelope([<<"You must specify either create_key or public_key, but not both">>]);
+malformed_request_message(private_key_field_not_supported, _Req, _State) ->
+    error_envelope([<<"Please use create_key: true instead of private_key: true">>]);
+malformed_request_message(key_management_not_supported, _Req, _State) ->
+    error_envelope([<<"Since Server API v1, all keys must be updated via the keys endpoint. ">>]);
+
+
 malformed_request_message(invalid_json_object, _Req, _State) ->
     error_envelope([<<"Incorrect JSON type for request body">>]);
 

--- a/apps/oc_chef_wm/src/chef_wm_named_data.erl
+++ b/apps/oc_chef_wm/src/chef_wm_named_data.erl
@@ -63,7 +63,7 @@
          request_type/0,
          validate_request/3,
          conflict_message/1,
-         finalize_create_body/3 ]).
+         finalize_create_body/4 ]).
 
 -export([
          allowed_methods/2,
@@ -140,7 +140,7 @@ from_json(Req, #base_state{resource_state = #data_state{data_bag_name = DataBagN
 
 % Callback from create_from_json, which allows us to customize our body response.
 finalize_create_body(_Req, #base_state{ resource_state = #data_state{data_bag_name = DataBagName,
-                                                                     data_bag_item_ejson = ItemData} }, _BodyEJ ) ->
+                                                                     data_bag_item_ejson = ItemData} }, _DataBagItem, _BodyEJ ) ->
     %% The Ruby API returns created items as-is, but with added chef_type and
     %% data_bag fields. If those fields are present in the request, they are put
     %% into the raw item data, but the values are overwritten for the return. When

--- a/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -44,7 +44,7 @@
 -export([check_cookbook_authz/3,
          delete_object/3,
          object_creation_hook/2,
-         object_creation_error_hook/2,
+         object_creation_error_hook/3,
          stats_hero_label/1,
          stats_hero_upstreams/0,
          is_superuser/1,
@@ -676,11 +676,22 @@ client_cleanup(#chef_client{authz_id=ClientAuthzId,
             {error, Error}
     end.
 
-object_creation_error_hook(#chef_data_bag_item{}, _RequestorId) ->
+object_creation_error_hook(_, #chef_data_bag_item{}, _RequestorId) ->
     ok;
-object_creation_error_hook(#chef_cookbook_version{}, _RequestorId) ->
+object_creation_error_hook(_, #chef_cookbook_version{}, _RequestorId) ->
     ok;
-object_creation_error_hook(Object, RequestorId) ->
+object_creation_error_hook(DbContext, #chef_user{id = Id} = Object, RequestorId) ->
+    % v1+ we create the key before the user
+    chef_db:delete(#chef_key{id = Id}, DbContext),
+    object_creation_error_authz_cleanup(Object, RequestorId);
+object_creation_error_hook(DbContext, #chef_client{id = Id} = Object, RequestorId) ->
+    % v1+ we create the key before the client
+    chef_db:delete(#chef_key{id = Id}, DbContext),
+    object_creation_error_authz_cleanup(Object, RequestorId);
+object_creation_error_hook(_DbContext, Object, RequestorId) ->
+    object_creation_error_authz_cleanup(Object, RequestorId).
+
+object_creation_error_authz_cleanup(Object, RequestorId) ->
     case chef_object:authz_id(Object) of
         undefined ->
             ok;
@@ -933,8 +944,7 @@ create_from_json(#wm_reqdata{} = Req,
         {conflict, _} ->
             %% ignore return value of solr delete, this is best effort.
             oc_chef_object_db:delete_from_solr(ObjectRec),
-            object_creation_error_hook(ObjectRec, ActorId),
-            %% FIXME: created authz_id is leaked for this case, cleanup?
+            object_creation_error_hook(DbContext, ObjectRec, ActorId),
             LogMsg = {RecType, name_conflict, Name},
             ConflictMsg = ResourceMod:conflict_message(Name),
             {{halt, 409}, chef_wm_util:set_json_body(Req, ConflictMsg),
@@ -945,15 +955,14 @@ create_from_json(#wm_reqdata{} = Req,
                                                 [ObjectRec, State], fun route_args/2),
             Uri = oc_chef_wm_routes:route(TypeName, Req, Args),
             BodyEJ0 = {[{<<"uri">>, Uri}]},
-            BodyEJ1 = call_if_exported(ResourceMod, finalize_create_body, [Req, State, BodyEJ0],
-                                       fun(_,_,EJ) -> EJ end),
+            BodyEJ1 = call_if_exported(ResourceMod, finalize_create_body, [Req, State, ObjectRec, BodyEJ0],
+                                       fun(_,_,_,EJ) -> EJ end),
             Req1 = chef_wm_util:set_json_body(Req, BodyEJ1),
             {true, chef_wm_util:set_location_of_created_resource(Uri, Req1), State#base_state{log_msg = LogMsg}};
         What ->
             %% ignore return value of solr delete, this is best effort.
-            %% FIXME: created authz_id is leaked for this case, cleanup?
             oc_chef_object_db:delete_from_solr(ObjectRec),
-            object_creation_error_hook(ObjectRec, ActorId),
+            object_creation_error_hook(DbContext, ObjectRec, ActorId),
             % 500 logging sanitizes responses to avoid exposing sensitive data -
             % TODO - parse sql error to get minimal meaningful message,
             % without exposing sensitive data
@@ -1031,6 +1040,7 @@ update_from_json(#wm_reqdata{} = Req, #base_state{chef_db_context = DbContext,
                     State1 = State#base_state{log_msg = Why},
                     % TODO - parse sql error to get minimal meaningful message,
                     % without exposing sensitive data
+                    lager:error("Error in object creation: ~p", [Why]),
                     {{halt, 500}, Req, State1}
             end
     end.

--- a/apps/oc_chef_wm/src/oc_chef_wm_key_base.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_key_base.erl
@@ -1,0 +1,111 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Marc Paradise <marc@chef.io>
+%% Copyright 2014 Chef Software, Inc
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(oc_chef_wm_key_base).
+-include("../../include/oc_chef_wm.hrl").
+
+-export([create_object_with_embedded_key_data/2,
+         update_object_embedded_key_data_v0/4,
+         finalize_create_body/3]).
+
+
+update_object_embedded_key_data_v0(Req, State, ObjectRec, EJ) ->
+case chef_key_base:maybe_generate_key_pair(EJ) of
+        keygen_timeout ->
+            {{halt, 503}, Req, State#base_state{log_msg = keygen_timeout}};
+        EJWithKeys->
+            oc_chef_wm_base:update_from_json(Req, State, ObjectRec, EJWithKeys)
+    end.
+
+% TODO owner_data should be moved to top-level object_ej [same with object_record] to avoid duplicating a subset of data
+% in multiple fields - and to generally simplify common object creation/validation/fetching behaviors.
+create_object_with_embedded_key_data(Req, #base_state{server_api_version = ?API_v0,
+                                                      key_context = #key_context{object_ej = EJ}} = State) ->
+    KeyData = case chef_key_base:cert_or_key(EJ) of
+                  {undefined, _} ->
+                      chef_keygen_cache:get_key_pair();
+                  {PubKey, _PubKeyVersion} ->
+                      {PubKey, undefined}
+              end,
+    create_object(KeyData, Req, State);
+create_object_with_embedded_key_data(Req, #base_state{key_context = #key_context{object_ej = EJ}} = State) ->
+    chef_key_base:maybe_generate_key_pair(EJ,
+                                          fun(Result) ->
+                                                  create_object(Result, Req, State)
+                                          end).
+
+create_object(keygen_timeout, Req, State) ->
+    {{halt, 503}, Req, State#base_state{log_msg = keygen_timeout}};
+create_object({PublicKey, PrivateKey},
+              Req, #base_state{server_api_version = ?API_v0,
+                               key_context = #key_context{object_ej = ObjectEJ, type = Type,
+                                                          object_authz_id = AuthzId} = KeyContext} = State) ->
+    EJ1 = chef_key_base:set_public_key(ObjectEJ, PublicKey),
+    KeyEJ =  {[{<<"private_key">>, PrivateKey},
+               {<<"public_key">>, PublicKey}]},
+    KeyContext1 = KeyContext#key_context{ object_ej = EJ1, key_ej = KeyEJ },
+    oc_chef_wm_base:create_from_json(Req,
+                                     State#base_state{ key_context = KeyContext1},
+                                     object_type(Type) , {authz_id, AuthzId}, EJ1);
+create_object({undefined, undefined},
+              Req, #base_state{key_context = #key_context{type = Type, object_authz_id = AuthzId,
+                                                          object_ej = EJ}} = State ) ->
+    % No public key was provided, and no key requested to be generated. Continue without additional action.
+    oc_chef_wm_base:create_from_json(Req, State, object_type(Type), {authz_id, AuthzId}, EJ);
+create_object({PublicKey, PrivateKey},
+              Req,
+              #base_state{server_api_version = Version, organization_guid = OrgId,
+                          requestor_id = ActorId, chef_db_context = Ctx,
+                          key_context = #key_context{type = OwnerType, object_ej = OwnerEJ,
+                                                     object_name = OwnerName,
+                                                     object_authz_id = OwnerAuthzId} = KeyContext} = State) ->
+    OrgId2 = safe_org_id(OrgId),
+    % Create the ID for the object ahead of time, we'll need it in our key.
+    ObjectId = chef_object_base:make_org_prefix_id(OrgId2, OwnerName),
+    #chef_key{key_name = KeyName} = Key = chef_object:new_record(chef_key, Version, OrgId2, unset, {ObjectId, chef_key:default_key_ejson(PublicKey)}),
+    case chef_db:create(Key, Ctx, ActorId) of
+        ok ->
+            URI = oc_chef_wm_routes:route(chef_key_base:key_owner_type(OwnerType), Req, [ {object_name, OwnerName}, {name, KeyName} ]),
+            KeyEJ = ej:set({<<"uri">>}, chef_key:ejson_from_key(Key), URI),
+            KeyEJ2 = case PrivateKey of
+                undefined -> KeyEJ;
+                _ -> ej:set({<<"private_key">>}, KeyEJ, PrivateKey)
+            end,
+            KeyContext2 = KeyContext#key_context{key_ej = KeyEJ2},
+            % By specifying the id in the EJ we'll ensure the object itself doesn't try to create it.
+            OwnerEJ1 = ej:set({<<"id">>}, OwnerEJ, ObjectId),
+            OwnerEJ2 = ej:delete({<<"create_key">>}, OwnerEJ1),
+            oc_chef_wm_base:create_from_json(Req, State#base_state{key_context = KeyContext2}, object_type(OwnerType), {authz_id, OwnerAuthzId}, OwnerEJ2);
+        What ->
+            % TODO DEBUGGING ONLY
+            lager:error("Failed to create key: ~p~n", [What]),
+            {{halt, 500}, Req, State#base_state{ log_msg = failed_to_save_new_key }}
+    end.
+
+finalize_create_body(_Req, #base_state{key_context = #key_context{key_ej = undefined}}, BodyEJ) ->
+    BodyEJ;
+finalize_create_body(_Req, #base_state{key_context = #key_context{key_ej = EJToEmbed}}, BodyEJ) ->
+    ej:set({<<"chef_key">>}, BodyEJ, EJToEmbed).
+
+safe_org_id(undefined) -> ?OSC_ORG_ID;
+safe_org_id(OrgId) -> OrgId.
+
+
+object_type(Type) -> list_to_existing_atom("chef_" ++ atom_to_list(Type)).

--- a/apps/oc_chef_wm/src/oc_chef_wm_keys.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_keys.erl
@@ -43,7 +43,7 @@
          route_args/2,
          to_json/2,
          auth_info/2,
-         finalize_create_body/3]).
+         finalize_create_body/4]).
 
 -export([allowed_methods/2,
          create_path/2,
@@ -88,7 +88,7 @@ make_resource_state_for_object(DbContext, user, Name, _OrgId) ->
 make_resource_state_for_object(_Type, not_found) ->
     #key_state{};
 make_resource_state_for_object(Type, Object) ->
-    FullType = list_to_existing_atom(atom_to_list(Type) ++ "_key"),
+    FullType = chef_key_base:key_owner_type(Type),
     #key_state{type = Type, full_type = FullType, parent_name = chef_object:name(Object),
                parent_authz_id = chef_object:authz_id(Object), parent_id = chef_object:id(Object)}.
 
@@ -132,21 +132,19 @@ to_json(Req, #base_state{ chef_db_context = DbContext,
         Error ->
             {{halt, 500}, Req, State#base_state{log_msg = Error }}
     end.
-from_json(Req, #base_state{resource_state = #key_state{key_data = EJ} = KeyState} = State) ->
-    case ej:get({<<"create_key">>}, EJ) of
-        true ->
-            case chef_keygen_cache:get_key_pair() of
-                {PublicKey, PrivateKey} ->
-                    EJ1 = ej:set({<<"public_key">>}, EJ, PublicKey),
-                    EJ2 = ej:delete({<<"create_key">>}, EJ1),
-                    KeyState2 = KeyState#key_state{generated_private_key = PrivateKey, key_data = EJ2},
-                    create_from_json(Req, State#base_state{resource_state = KeyState2});
-                keygen_timeout ->
-                    {{halt, 503}, Req, State#base_state{log_msg = keygen_timeout}}
-            end;
-        _ ->
-            create_from_json(Req, State)
-    end.
+
+from_json(Req, #base_state{resource_state = #key_state{key_data = EJ}} = State) ->
+    chef_key_base:maybe_generate_key_pair(EJ, fun(Result) -> handle_keypair(Req, State, Result) end).
+
+handle_keypair(Req, State, keygen_timeout) ->
+    {{halt, 503}, Req, State#base_state{log_msg = keygen_timeout}};
+handle_keypair(Req, State, {_, undefined}) ->
+   create_from_json(Req, State);
+handle_keypair(Req, #base_state{resource_state = KeyState} = State, {PublicKey, PrivateKey}) ->
+    EJ1 = ej:set({<<"public_key">>}, KeyState#key_state.key_data, PublicKey),
+    EJ2 = ej:delete({<<"create_key">>}, EJ1),
+    KeyState2 = KeyState#key_state{generated_private_key = PrivateKey, key_data = EJ2},
+    create_from_json(Req, State#base_state{resource_state = KeyState2}).
 
 create_from_json(Req, #base_state{resource_state = #key_state{key_data = EJ, parent_id = ActorId}} = State) ->
     oc_chef_wm_base:create_from_json(Req, State, chef_key, {authz_id, undefined}, {ActorId, EJ}).
@@ -164,7 +162,7 @@ route_args(#chef_key{key_name = Name},
     {FullType, [{name, Name}, {object_name, ObjectName}] }.
 
 % Callback from create_from_json, which allows us to customize our body response.
-finalize_create_body(_Req, #base_state{ resource_state = #key_state{generated_private_key = undefined}}, BodyEJ) ->
+finalize_create_body(_Req, #base_state{ resource_state = #key_state{generated_private_key = undefined}}, _Key, BodyEJ) ->
     BodyEJ;
-finalize_create_body(_Req, #base_state{ resource_state = #key_state{generated_private_key = GenPrivKey}}, BodyEJ) ->
+finalize_create_body(_Req, #base_state{ resource_state = #key_state{generated_private_key = GenPrivKey}}, _Key, BodyEJ) ->
     ej:set({<<"private_key">>}, BodyEJ, GenPrivKey).

--- a/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
@@ -179,13 +179,12 @@ from_json(Req, #base_state{resource_args = invitation_response,
                     {true, chef_wm_util:set_json_body(Req1, EJResponse), State1}
             end
     end;
+from_json(Req, #base_state{server_api_version = ?API_v0,
+                           resource_state = #user_state{ chef_user = User, user_data = UserData}} = State) ->
+    oc_chef_wm_key_base:update_object_embedded_key_data_v0(Req, State, User, UserData);
 from_json(Req, #base_state{resource_state = #user_state{ chef_user = User, user_data = UserData}} = State) ->
-    case chef_key_base:maybe_generate_key_pair(UserData) of
-        keygen_timeout ->
-            {{halt, 503}, Req, State#base_state{log_msg = keygen_timeout}};
-        UserDataWithKeys ->
-            oc_chef_wm_base:update_from_json(Req, State, User, UserDataWithKeys)
-    end.
+    % in v1+ keys may only be updated via the keys endpoint.
+    oc_chef_wm_base:update_from_json(Req, State, User, UserData).
 
 finalize_update_body(Req, _State, BodyEJ) ->
     %% Custom json body needed to maintain compatibility with opscode-account behavior.

--- a/apps/oc_chef_wm/src/oc_chef_wm_routes.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_routes.erl
@@ -110,7 +110,6 @@ org_route(organization, Req, Args) ->
     TemplateArgs = [Name],
     render_template(Template, Req, TemplateArgs);
 org_route(client_key, Req, Args) ->
-    Org = org_name(Req),
     {object_name, ParentName} = lists:keyfind(object_name, 1, Args),
     {name, Name} = lists:keyfind(name, 1, Args),
     {BaseURI, Org} = extract_from_req(Req),

--- a/include/oc_chef_wm.hrl
+++ b/include/oc_chef_wm.hrl
@@ -78,6 +78,17 @@
 
 -type wm_req() :: #wm_reqdata{}.
 
+
+-record(key_context, {
+          type,
+          object_ej,
+          object_name,
+          object_authz_id,
+          key_ej,  % ejson to inject into body response
+
+          % deprecated support for api v0 in client/user creation:
+          private_key
+         }).
 %% Shared resource state shared by all chef_wm resource modules.
 -record(base_state, {
           %% Concrete resource impl
@@ -174,13 +185,18 @@
           %% list of resource arguments passed in on init of each resource by webmachine
           %% This will be set to 'Value' of a tuple in the resource argument list in
           %% dispatch.conf matching the form {resource_args, Value}
-          resource_args :: list()
+          resource_args :: list(),
+
+          % Multiple resources may create a key at time of object creation.  Expose it
+          % in base_state so that it's available for common handling.
+          key_context ::undefined | #key_context{}
+
          }).
 
 -record(client_state, {
           client_data,
           client_authz_id,
-          keydata,
+          generated_private_key,
           chef_client :: #chef_client{} | not_found
          }).
 
@@ -279,7 +295,7 @@
 -record(user_state, {
           user_data,
           user_authz_id,
-          keydata,
+          generated_private_key,
           chef_user :: #chef_user{}
       }).
 
@@ -341,6 +357,8 @@
           generated_private_key,
           chef_key :: #chef_key{}
          }).
+
+
 
 -define(gv(X,L), proplists:get_value(X, L)).
 -define(gv(X,L, D), proplists:get_value(X, L, D)).

--- a/include/server_api_version.hrl
+++ b/include/server_api_version.hrl
@@ -10,8 +10,8 @@
 % and not product version.
 -define(API_v1, 1).
 
-%% Which level of API version is deprecated? Not currently used by
-%% erchef, this is for human consumption.
+%% Highest level of deprecated API version that will be removed in the nxt major product release.
+%% This is used in eunit tests for version range testing across objects.
 -define(API_DEPRECATED_VER, ?API_v0).
 
 


### PR DESCRIPTION
ChangeLog-Entry: This introduces new, consistent handling of keys across
the clients, users, and keys endpoints.  It disables the updating of keys
via the clients and users endpoints - all keys are to be managed via the
keys endpoints after initial creation. This deprecates the previous key
creation and update, though it is still supported for backwards
compatibility.

This PR replaces https://github.com/chef/oc_erchef/pull/139 which was based against the wrong branch. 

ping @chef/lob 