### PR TITLE
a self-contained development environment

### DIFF
--- a/dev/.bashrc
+++ b/dev/.bashrc
@@ -1,0 +1,2 @@
+PATH=/opt/opscode/embedded/bin:$PATH
+

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+testdata

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,132 @@
+##  Welcome!
+
+You have found the chef-server self-contained development environment.
+It aims to get you up and hacking on chef-server components in a
+safe, pain-free manner.
+
+In short it will create a simple Vagrant VM, while still allowing you to do
+your development from the comfort of your own host. Changes to make are
+either instantly loaded (erlang projects with sync support) or instantly
+available on the guest vm.
+
+## Quick Start
+
+Assuming you'd like to be able to modify oc_erchef, its omnibus
+cookbooks, and run/modify pedant tests:
+
+```
+cd dev
+vagrant up  # this takes 3-5 minutes depending on your machine
+vagrant rsync-auto > /dev/null 2>&1 & 
+vagrant ssh
+sudo -i
+tmux # recommended, not required.
+dvm quickstart oc_erchef
+```
+
+And if you want to verify that things are behaving ok, from inside the
+VM as root:
+```
+dvm run oc-chef-pedant
+```
+
+You can also provide the usual flags, eg `dvm run oc-chef-pedant
+--focus-/skip-X`, `--all`, etc.
+
+Now, start modifying things on your host. You'll notice the
+following:
+
+* Any change to erchef files will automatically compile and (if no
+  errors) load into the running erchef instance now on your screen.
+  You can see this activity happen in the running instance.
+* changes to opscode-omnibus/fils/private-chef-cookbooks are sync'd on the guest.
+  Change them on the host then run reconfigure to pick up the changes.
+* Similarly oc-chef-pedant is sync'd.  At any time you want to run  your
+  modifications you can `dvm run oc-chef-pedant`. Focus tags, etc are
+  respected normally.
+
+If you want to load in omnibus partybus upgrade migrations or commands
+for testing you can (from within the vm):
+
+* dvm load omnibus upgrades
+* dvm load omnibus ctl-commands
+
+Note that the standard basic VM management comments for vagrant
+(suspend/halt/destroy/etc) work normally.
+
+TODO: If you want to load in test users, orgs, and nodes for testing outside
+of pedant, you can:
+
+`dvm populate all`
+
+Or if you don't want anything:
+* `dvm populate users
+* `dvm populate orgs` (Also creates users listed as associated with the orgs.)
+* `dvm populate nodes
+
+### Wait what just happened?
+
+The dvm `quickstart` command loads several projects for you. Take a
+look at defaults.yml under "quickstart" and you will see:
+
+```
+    load:
+      - omnibus private-chef-cookbooks
+      - oc-chef-pedant
+      - oc_erchef
+    start:
+      - oc_erchef --foreground
+```
+
+What this is the equivalent of doing is:
+
+```
+dvm load omnibus private-chef-cookbooks # load in cookbooks
+dvm load oc-chef-pedant # load in oc-chef-pedant  bundle installing as needed
+dvm load oc_erchef # build and load oc_erchef
+dvm start oc_erchef  --foreground
+```
+
+And it does just what it says. You can add your own quickstart
+configurations - or override the existing ones - in config.yml.
+Currently 'load' and 'start' are the supported sections since in
+practice that's what's been neeeded so far.
+
+
+## PreReqs
+
+Assuming that you're looking to do oc_erchef and/or opscode-omnibus
+development:
+
+* 8vcores and enough ram to do development with (16GB+, but 8 might
+  work...)
+* vagrant 1.7+ - earlier versions may work but are not tested
+* virtualbox 4.3 (as tested, other versions may/may not work)
+* A directory containing your checked out chef server projects. These
+  should be at the same level. Because this directory is rsync'd with the
+  VM (other options didn't give acceptable performance) try to avoid including
+  too many unrelated projects. For the erchef quickstart you will need:
+  * oc_erchef
+  * opscode-omnibus
+  * oc-chef-pedant
+
+###  dvm
+
+dvm is a command line tool used to manage the environment from within
+the vm.  It must always be run as root, and to be sure that the
+environment is correct, use `sudo -i` to become root to run it.
+
+The intention here was to create a simple way to do all the
+common activities:
+
+* load a project
+* run a test suite or subset thereof
+* run a project and/or start a loaded service
+* open a console to a running erlang app
+* etop a running erlang app
+* access the DB for a project
+
+And a few other things.  You can just use `dvm` by itself and a list of
+commands will be generated. You may also want to take a look in
+defaults.yml, in which project definitions and other things are set up.
+

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -1,0 +1,26 @@
+- [ ] MOTD with some useful instructions and available commands
+- [ ] populate command to load test users and orgs
+- [ ] simple merge of vm settings in config.yml and default.yml files so that
+      packages and vm config can be overridden.
+- [ ] Once that's done, update config.yml  with basic skeleton to show what can be done,
+      then add to .gitignore
+- [ ] verify `bookshelf` and `oc_bifrost` work without further
+      modification
+- [ ] option to auto-modify /etc/hosts to add thte vm name
+      Also ensure DNS for named host resolves to external IP and
+      everything works with this.
+- [ ] for each project setting - or just at vm level? , add forward_ports. Note that user knife
+      config, etc should work from in the vm or from the host.
+- [ ] Should we default quickstart ercehf to launch in the background to
+      avoid another ssh session for more work? One the one hand, simpler
+      to start, on the other hand it's nice to see the immediate errors/info
+      feedback when you get started...
+- [ ] It would be simple to do automatic git checkout of project dependencies on
+      requested load, but ultimately not helpful because we're using
+      vagrant rsync - the sync is one way, and the checked out projects won't
+      show up on the host.  One option to do this is to *additional* load in
+      the host location as a standard vbox share  and mount it to /host_rw or something.
+      Convoluted but it would work.
+- [ ] not really any support for ruby project deps, something that we
+      will want if we expand this to support the things that layer atop chef
+      server (manage, etc)

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -1,0 +1,169 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby
+
+require "yaml"
+
+Vagrant.configure("2") do |config|
+  provisioning, installer, installer_path, attributes = prepare()
+  config.vm.box     = "oc_erchef-ubuntu-14.04"
+  config.vm.box_url= "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
+  config.vm.hostname = "api.chef-server.dev"
+  config.vm.network "private_network", ip: "33.33.33.100"
+
+  begin
+    custom_config = YAML.load_file("config.yml")
+    num_cpus = custom_config["vm"]["cpus"]
+    mem = custom_config["vm"]["memory"]
+  rescue
+  end
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id,
+                  "--name", "chef-server",
+                  "--memory", mem || 4096,
+                  "--cpus", num_cpus || 4,
+                  "--natdnshostresolver1", "on",
+                  "--usb", "off",
+                  "--usbehci", "off",
+                  "--nictype1", "virtio",
+                  "--nictype2", "virtio"
+                  # ^ TODO if platform is mac don't?
+    ]
+    vb.customize [
+      "storagectl", :id,
+      "--name", "IDE Controller",
+      "--hostiocache", "on"
+    ]
+  end
+
+  if provisioning
+    # TODO - simple merge of config.yml vm packages as well
+    json = {
+      "packages" => attributes["vm"]["packages"],
+      "tz" => host_timezone
+    }
+    # Assumes residence in dev/oc_erchef, with interesting tidbits up one level from that
+    # Note that we can't exclude .git from top-level projects, and by extension from anything,
+    # otherwise rebar commands begin to fail. Note that we also exclude a lot of things we don't want to pull
+    # in from the host since we will generate them ourselves in the session.We also include a couple of projects
+    # that may exist in your host directory that we don't want to spend time on.
+    config.vm.synced_folder File.absolute_path(File.join(Dir.pwd, "../..")), "/host",
+      type: "rsync",
+      rsync__exclude: attributes["vm"]["sync-exclude"]
+
+   # We're also going to do a share of the slower vboxsf style, allowing us to auto-checkout dependencies
+    # and have them be properly synced to a place that we can use them.
+    config.vm.synced_folder base_path, "/mnt/host-do-not-use"
+    config.vm.synced_folder installer_path, "/installers"
+    config.vm.provision "shell", inline: install_hack(installer)
+    config.vm.provision "chef_solo" do |chef|
+      chef.install = false
+      chef.binary_path = "/opt/opscode/embedded/bin"
+      chef.node_name = config.vm.hostname
+      chef.cookbooks_path = "cookbooks"
+      chef.add_recipe("provisioning::chef-server")
+      chef.add_recipe("dev::system")
+      chef.add_recipe("dev::dvm")
+      chef.add_recipe("dev::user-env")
+      chef.json = json || {}
+    end
+  end
+end
+
+##############
+# Internals
+##############
+# These functions are used for provisioning, and ensuring that the VM has
+# what it needs to load up and install chef-server
+##############
+
+
+def prepare
+  action = ARGV.shift
+  if action =~ /^(provision|up|reload)$/
+    attributes = YAML.load_file("defaults.yml")
+    installer = ENV['INSTALLER'] || prompt_installer
+    raise "Please set INSTALLER to the path of a .deb package for Chef Server 12+." if installer.nil?
+    raise "#{installer} does not exist! Please fix this." unless File.file?(installer)
+    puts "*** Found #{installer}, will use this if an install is necessary"
+    installer_path = File.dirname(File.expand_path(installer))
+    provisioning = true
+  end
+  [provisioning, installer, installer_path, attributes]
+end
+
+def prompt_installer
+  # TODO allow config override of location, multiple locations, search pattern, max count?
+  files = Dir.glob("#{Dir.home}/Downloads/chef-server-core*.deb") + Dir.glob("#{base_path}/opscode-omnibus/pkg/chef-server-core*.deb")
+
+  if files.length ==  0
+    return nil
+  end
+  if files.length == 1
+    return files[0]
+  end
+
+  files = files.sort_by{ |f| File.mtime(f) }.last(10)
+  files.reverse!
+  cur = 1
+  files.each do |f|
+    puts " #{cur}) #{f}\n"
+    cur = cur + 1
+  end
+  selection = 0
+  loop do
+    print "Which Image? [1 - #{files.length}]: "
+    selection = gets.chomp.to_i
+    break if selection > 0 and selection <= files.length
+  end
+  files[selection - 1]
+
+end
+
+def host_timezone
+  require "time"
+  # Note that we have to reverse the offset sign if we're using Etc/GMT,
+  # reference: http://en.wikipedia.org/wiki/Tz_database#Area
+#  offset = (Time.zone_offset(Time.now.zone) / 3600) * -1
+#  zonesuffix = offset >= 0 ? "+#{offset.to_s}" : "#{offset.to_s}"
+#  "Etc/GMT#{zonesuffix}"
+  #  Sigh - sqitch doesn't like the above format and dies.
+  #  This is temporary and won't work on mac:
+  if /darwin/ =~ RUBY_PLATFORM
+
+    puts "Notice: using sudo to get timezone, no updates being made"
+    puts "Executing: sudo systemsetup -gettimezone"
+    # Time Zone: Blah/Blah
+    `sudo systemsetup -gettimezone`.chomp.split(":")[1].strip
+  else # TODO windows if we otherwise check out for windows.
+    `cat /etc/timezone`.chomp
+  end
+  #
+end
+
+# this is here in order to avoid having to download a chef provisioner -
+# we already have a chef-client install included with the server package, and since
+# we're going to run in solo mode, it will run for VM provisioning without
+# interfering with the server install.
+def install_hack(installer)
+  server_installer_name = File.basename(installer)
+  return ";" if server_installer_name.nil?
+<<SCRIPT
+if [ -d "/opt/opscode/embedded" ]
+then
+  echo "Bypassing server install, it appears done."
+else
+  echo "PATH=/opt/opscode/embedded/bin:$PATH" > /root/.bashrc
+  sudo dpkg -i /installers/#{server_installer_name}
+fi
+SCRIPT
+end
+def simple_deep_merge(from, into)
+  into.merge(from) do |key, oldval, newval|
+    oldval = oldval.to_hash if oldval.respond_to?(:to_hash)
+    newval = newval.to_hash if newval.respond_to?(:to_hash)
+    oldval.class.to_s == 'Hash' && newval.class.to_s == 'Hash' ? simple_deep_merge(oldval, newval) : newval
+  end
+end
+def base_path
+  File.absolute_path(File.join(Dir.pwd, "../.."))
+end

--- a/dev/config.yml
+++ b/dev/config.yml
@@ -1,0 +1,5 @@
+# Place any complete or partial overrides to the configuration in defaults.yml here.
+# Map entries wlll be replaced, and you can remove from defaults by prefixing with --, for example:
+#
+# vm:
+#   packages: [ --vim, emacs24 ]

--- a/dev/cookbooks/dev/files/default/b2f
+++ b/dev/cookbooks/dev/files/default/b2f
@@ -1,0 +1,75 @@
+#! /usr/bin/env escript
+
+%% -*- mode: erlang -*-
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+%%
+%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+main([Cmd]) when Cmd == "help";
+                 Cmd == "--help";
+                 Cmd == "-h" ->
+    io:format("b2f: Beam To Function decompiler~n"),
+    io:format("Usage: b2f beam_file [function_names]~n"),
+    io:format("Notes: beam_file must be a valid path to a BEAM file with debug info.~n"),
+    io:format("       function_names are optional. If given, they must be a space-delimited list of~n"),
+    io:format("       function names to dump.~n");
+main([FileName|Funs]) ->
+    case file:read_file(FileName) of
+        {error, Reason} ->
+            exit(Reason);
+        {ok, Contents} ->
+            {ok, Chunk} = beam_lib:chunks(Contents, [abstract_code]),
+            {Mod, [{abstract_code, {raw_abstract_v1, Code}}]} = Chunk,
+            io:format("~n"),
+            dump_function(Mod, Code, Funs)
+    end.
+
+dump_function(Mod, Code, Funs) ->
+    MaskF = function_mask(Funs),
+    FinalFuns = [F || F <- Code,
+                      MaskF(F) == true],
+    pretty_print(Mod, FinalFuns).
+
+function_mask("") ->
+    fun({function, _, _, _, _}) ->
+            true;
+       (_) ->
+            false
+    end;
+function_mask(Names0) ->
+    Names = [list_to_atom(N) || N <- Names0],
+    fun({function, _, Name, _, _}) ->
+            lists:member(Name, Names);
+       (_) ->
+            false
+    end.
+
+pretty_print(_Mod, []) ->
+    ok;
+pretty_print(Mod, [{function, Line, Name, Arity, Body0}|T]) ->
+    Body = erl_prettypr:format(erl_syntax:form_list(Body0)),
+    io:format("[~p.erl:~p] ~p:~p/~p~n", [Mod, Line, Mod, Name, Arity]),
+    io:format("~p~s~n", [Name, Body]),
+    case T of
+        [] ->
+            ok;
+        _ ->
+            io:format("====================~n"),
+            pretty_print(Mod, T)
+    end.

--- a/dev/cookbooks/dev/files/default/user_default.erl
+++ b/dev/cookbooks/dev/files/default/user_default.erl
@@ -1,0 +1,60 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+%%
+%% @author Marc Paradise <marc@chef.io>
+%%
+-module(user_default).
+% required to expose the record definitions we load in from various includes
+-compile(export_all).
+%
+% Invoke this from the erlang shell to reload a module in place
+% for example, um(oc_chef_wm_base).
+%
+% May not always behave well if you're reload a module used
+% by a running process, though it does attempt to unload and purge
+% any existing instances before loading.
+%
+% Note that this does not update deployed beam files. If you stop the oc_erchef
+% process you'll need to run make (or make compile_skip) to make sure all
+% modules you've updated in the process of iterating get pulled in.
+%
+um(Mod) ->
+    Info = Mod:module_info(),
+    CompileInfo = proplists:get_value(compile, Info),
+    Path = proplists:get_value(source, CompileInfo),
+    Options = [{d, 'OC_CHEF'},
+               {debug_info, debug_info},
+               {d,'CHEF_WM_DARKLAUNCH',xdarklaunch_req},
+               {d,'CHEF_DB_DARKLAUNCH',xdarklaunch_req},
+               {parse_transform,lager_transform},
+               {i, "include"},
+               return,
+               binary],
+
+    case compile:file(Path, Options) of
+        {ok, _Mod, Bin, []} ->
+            Reload = reload(Mod, Path, Bin),
+            {{reload, Reload}, ok};
+        {ok, _Mod, Bin, Warnings} ->
+            Reload = reload(Mod, Path, Bin),
+            {{reload, Reload}, {warnings, Warnings}};
+        {ok, _Mod, Bin} ->
+            Reload = reload(Mod, Path, Bin),
+            {{reload, Reload}, ok};
+        Error ->
+            {errors, Error}
+    end.
+
+
+reload(Mod, Path, Binary) ->
+    code:delete(Mod),
+    code:purge(Mod),
+    code:load_binary(Mod, Path, Binary).
+
+db_ctx() ->
+    chef_db:make_context(<<"ABCD">>).
+
+% You can use this from the shell to load up record definitions:
+% [rr(Path) || Path <- headers()].
+headers() ->
+    ["/srv/piab/mounts/oc_erchef/include/chef_types.hrl","/srv/piab/mounts/oc_erchef/include/oc_chef_authz.hrl", "/srv/piab/mounts/oc_erchef/include/oc_chef_types.hrl"].

--- a/dev/cookbooks/dev/libraries/dvm_helper.rb
+++ b/dev/cookbooks/dev/libraries/dvm_helper.rb
@@ -1,0 +1,13 @@
+require "pathname"
+
+module DVMHelper
+  def self.dvm_path
+    path = `gem which dvm 2>&1`
+    if path =~ /^ERROR.*/
+      nil
+    else
+      # comes back as PATH/dvm/dvm.rb
+      Pathname.new(path).parent.parent.to_s
+    end
+  end
+end

--- a/dev/cookbooks/dev/metadata.rb
+++ b/dev/cookbooks/dev/metadata.rb
@@ -1,0 +1,5 @@
+name "dev"
+version "0.0.1"
+description "Development environment setup"
+
+

--- a/dev/cookbooks/dev/recipes/dvm.rb
+++ b/dev/cookbooks/dev/recipes/dvm.rb
@@ -1,0 +1,34 @@
+# dvm gem and project setup. This one is ugly...
+#
+
+
+execute "install deep_merge" do
+  command <<-EOM
+export PATH=/opt/opscode/embedded/bin:$PATH
+cd /tmp
+git clone https://github.com/danielsdeleo/deep_merge.git
+cd deep_merge
+rake package
+gem install -l pkg/deep_merge-1.0.1.gem
+rm -rf /tmp/deep_merge
+EOM
+  only_if { DVMHelper.dvm_path.nil? }
+end
+
+execute "install and load dvm" do
+  cwd "/vagrant/dvm"
+  command <<-EOM
+# Build and install dvm
+gem build dvm.gemspec
+gem install -l dvm-100.0.0.gem
+rm dvm-100.0.0.gem
+EOM
+  only_if { DVMHelper.dvm_path.nil? }
+end
+
+mount "dvm" do
+  mount_point lazy { DVMHelper.dvm_path }
+  device "/vagrant/dvm"
+  fstype "none"
+  options "bind"
+end

--- a/dev/cookbooks/dev/recipes/system.rb
+++ b/dev/cookbooks/dev/recipes/system.rb
@@ -1,0 +1,38 @@
+## System setup
+node['packages'].each do |p|
+  package p
+end
+
+# Time and zone should match the host so that erlang's sync module plays nicely with vagrant rsync
+file "/etc/timezone" do
+  content node["tz"]
+  owner 'root'
+  group 'root'
+  mode 0644
+  notifies :run, 'bash[dpkg-reconfigure tzdata]'
+end
+
+bash 'dpkg-reconfigure tzdata' do
+  user 'root'
+  code "/usr/sbin/dpkg-reconfigure -f noninteractive tzdata"
+  action :nothing
+end
+
+
+template "/etc/profile.d/omnibus-embedded.sh" do
+  source "omnibus-embedded.sh.erb"
+  owner "root"
+  user "root"
+  mode "0600"
+end
+
+template "/etc/sudoers" do
+  source "sudoers"
+  action :create
+  owner "root"
+  user "root"
+  mode 0440
+end
+
+
+

--- a/dev/cookbooks/dev/recipes/user-env.rb
+++ b/dev/cookbooks/dev/recipes/user-env.rb
@@ -1,0 +1,60 @@
+# User-specific setup
+directory "/home/vagrant/.ssh" do
+  action :create
+  owner "vagrant"
+  group "vagrant"
+  mode "0700"
+end
+
+template "/home/vagrant/.ssh/ssh_config" do
+  source "ssh_config"
+  action :create
+  owner "vagrant"
+  user "vagrant"
+  mode "600"
+end
+
+[["root", "/root"],["vagrant", "/home/vagrant"]].each do |user|
+  who, homedir = user
+  directory "#{homedir}/bin" do
+    action :create
+    owner who
+    user who
+  end
+
+  file "#{homedir}/.erlang" do
+    content "code:load_abs(\"#{homedir}/bin/user_default\")."
+    action :create
+    owner who
+    user who
+  end
+
+  cookbook_file "user_default.erl" do
+    path "#{homedir}/bin/user_default.erl"
+    action :create_if_missing
+    source "user_default.erl"
+    owner who
+    user who
+  end
+  execute "set up user_default for erlang console use" do
+    command "/opt/opscode/embedded/bin/erlc user_default.erl"
+    cwd "#{homedir}/bin"
+  end
+
+  cookbook_file "b2f" do
+    path "#{homedir}/bin/b2f"
+    mode "0777"
+    action :create
+    owner who
+    user who
+  end
+end
+
+directory "/vagrant/testdata/keys" do
+  action :create
+  recursive true
+end
+directory "/vagrant/testdata/orgs" do
+  action :create
+  recursive true
+end

--- a/dev/cookbooks/dev/templates/default/omnibus-embedded.sh.erb
+++ b/dev/cookbooks/dev/templates/default/omnibus-embedded.sh.erb
@@ -1,0 +1,3 @@
+export DEVVM=1
+export USE_SYSTEM_GECODE=1
+export PATH=/opt/opscode/embedded/bin:$HOME/bin:/opt/opscode/embedded/jre/bin:/usr/local/sbin/us/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/dev/cookbooks/dev/templates/default/ssh_config
+++ b/dev/cookbooks/dev/templates/default/ssh_config
@@ -1,0 +1,4 @@
+
+Host github.com
+  StrictHostKeyChecking no
+

--- a/dev/cookbooks/dev/templates/default/sudoers
+++ b/dev/cookbooks/dev/templates/default/sudoers
@@ -1,0 +1,5 @@
+<% # We do not use env_keep - sudo then lets you share the /vagrant .bashrc and home settings  %>
+opscode ALL=(ALL:ALL) ALL
+root ALL=(ALL:ALL) ALL
+vagrant ALL=(ALL) NOPASSWD:ALL
+

--- a/dev/cookbooks/provisioning/metadata.rb
+++ b/dev/cookbooks/provisioning/metadata.rb
@@ -1,0 +1,4 @@
+version "0.0.1"
+description "package provisioning"
+name "provisioning"
+

--- a/dev/cookbooks/provisioning/recipes/chef-server.rb
+++ b/dev/cookbooks/provisioning/recipes/chef-server.rb
@@ -1,0 +1,58 @@
+# Bare minimum packages for other stuff to work:
+execute "apt-get-update" do
+  command "apt-get update"
+  ignore_failure true
+  not_if do
+    File.exists?('/var/chef/cache/apt-update-done')
+  end
+end
+
+file "/var/chef/cache/apt-update-done" do
+  action :create
+end
+package "build-essential"
+package "git"
+
+# Install required external packages.
+# TODO eventually support auto-download of these packages from packagecloud
+ #node['chef-server']['installers'].each do |package_name|
+  #package package_name do
+    #source "/installers/#{package_name}"
+    #provider Chef::Provider::Package::Dpkg
+    #action :install
+    #not_if { File.exists? "/var/chef/cache/#{package_name}-installed" }
+  #end
+  #file "/var/chef/cache/#{package_name}-installed" do
+    #action :create
+  #end
+
+#end
+
+directory "/etc/opscode" do
+  owner "root"
+  group "root"
+  recursive true
+  action :create
+end
+
+template "/etc/opscode/chef-server.rb" do
+  source "chef-server.rb.erb"
+  owner "root"
+  group "root"
+  action :create
+  notifies :run, "execute[reconfigure]", :immediately
+end
+
+template "/etc/hosts" do
+  source "hosts.erb"
+  owner "root"
+  group "root"
+  action :create
+  variables({"fqdns" => ["api.chef-server.dev",  "manage.chef-server.dev" ]})
+end
+
+execute "reconfigure" do
+  command "chef-server-ctl reconfigure"
+  action :nothing
+end
+

--- a/dev/cookbooks/provisioning/templates/default/chef-server.rb.erb
+++ b/dev/cookbooks/provisioning/templates/default/chef-server.rb.erb
@@ -1,0 +1,4 @@
+api_fqdn "api.chef-server.dev"
+
+topology "standalone"
+

--- a/dev/cookbooks/provisioning/templates/default/hosts.erb
+++ b/dev/cookbooks/provisioning/templates/default/hosts.erb
@@ -1,0 +1,6 @@
+127.0.0.1 localhost <%=@fqdns%> api manage
+::1 localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+

--- a/dev/cookbooks/provisioning/templates/default/hosts.erb
+++ b/dev/cookbooks/provisioning/templates/default/hosts.erb
@@ -1,4 +1,5 @@
-127.0.0.1 localhost <%=@fqdns%> api manage
+127.0.0.1 localhost
+33.33.33.100 <%=@fqdns%> api manage
 ::1 localhost ip6-localhost ip6-loopback
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -1,0 +1,154 @@
+vm:
+  packages: [ ntp, curl, wget, htop, uuid-dev, tmux, vim, iotop ]
+  installer-list-max-size: 10
+  # TODO whitelist as well?
+  sync-exclude:
+    - pkg/
+    - deps/
+    - _rel/
+    - opscode-dev-vm/
+    - chef-docs/ # Huge if you have it checked out!
+    - ebin/
+    - .eunit/
+    - .kitchen/
+    - "*_SUITE_data/"
+    - "*.deb"
+    - "*.rpm"
+    - "*.vmdk"
+    - "*.plt"
+    - "*.beam"
+    - rspec.failures
+
+projects:
+  oc_erchef:
+    type: erlang
+    database: opscode_chef # Used for dvm psql oc_erchef
+    service:
+      rel-type: relx
+      name: opscode-erchef
+      cookie: erchef
+      node: erchef@127.0.0.1
+  oc_bifrost: # TODO : unverified
+    type: erlang
+    database: opscode_bifrost
+    service:
+      rel-type: relx
+      name:  oc_bifrost
+      cookie: oc_bifrost
+      node: oc_bifrost@127.0.0.1
+  bookshelf: # TODO unverified
+    type: erlang
+    service:
+      rel-type: relx
+      name:  bookhself
+      cookie: bookshelf
+      node: bookshelf@127.0.0.1
+  omnibus:
+    type: omnibus
+    git:
+      uri: git@github.com:chef/opscode-omnibus.git
+      branch: master
+    components:
+      # dest paths are relative to /opt/opscode/embedded for these components
+      # source apths are relative to opscode-omnibus/files
+      private-chef-cookbooks:
+        source_path: private-chef-cookbooks/private-chef
+        dest_path: cookbooks/private-chef
+        reconfigure_on_load: true
+      ha-drdb-cookbook:
+        source_path: private-chef-cookbooks/chef-ha-drdb
+        dest_path: cookbooks/chef-ha-drdb
+        reconfigure_on_load: true
+      ctl-commands:
+        source_path: private-chef-ctl-commands
+        dest_path: service/omnibus-ctl
+        reconfigure_on_load: false
+      upgrades:
+        source_path: private-chef-upgrades
+        dest_path: upgrades
+        reconfigure_on_load: false
+
+  oc-chef-pedant:
+    type: ruby
+    database: opscode_chef
+    run: "bin/oc-chef-pedant -c /var/opt/opscode/oc-chef-pedant/etc/pedant_config.rb"
+
+  #TODO
+  # fixie:
+  #   type: ruby
+  #
+
+
+quickstart:
+  oc_erchef:
+    description: "Load up cookbooks, oc-chef-pedant, and oc_erchef from /host. Start oc_erchef into a console."
+    load:
+      - omnibus private-chef-cookbooks
+      - oc-chef-pedant
+      - oc_erchef
+    start:
+      - oc_erchef
+  omnibus:
+    description: "Load most omnibus components (private-chef-cookbook, ctl-commands, upgrades) and run reconfigure"
+    load:
+      - private-chef-cookbooks
+      - ctl-commands
+      - upgrades
+  oc_bifrost:
+    description: "Load cookbooks, oc_bifrost, oc-bifrost-pedant, and oc_bifrost from /host. Start oc_bifrost into a console."
+    load:
+      - omnibus private-chef-cookbooks
+      - oc-bifrost-pedant
+      - oc_bifrost
+    start:
+      - oc_bifrost
+
+# NOTE
+# The orgs and users below are NOT created by default. To create them at any time,
+# invoke:
+#
+#   dvm populate users
+#   dvm populate orgs
+#
+# Or to save some typing:
+#   dvm populate all
+#
+# TODO this should live in the readme.
+# Under /vagrant/testdata (or oc_erchef/dvm/testdata on the host) the following will be populated,
+# depending on which 'populate' command you've run:
+#
+# keys/
+#   -> all user keys except pivotal (which is in /etc/opscode)
+# pivotal/  Pivotal can only be used from inside the vm
+#   .chef/chef-shell.rb for pivotal
+#   .chef/knife.rb for pivotal, but note that this will not be configured for an org, so is primarily
+#                  useful for knife raw
+#
+# orgs/
+#    each-orgname/
+#       orgname-validator.pem
+#       nodes/
+#         each-nodename/
+#           .chef/nodename-client.pem
+#           .chef/chef-client.rb
+#       users/
+#         each-username/
+#           .chef/knife.rb (will refer back to ../../keys/username-key.pem)
+
+orgs:
+  ponyville:
+    admins: [ applejack ]
+    users: [ applejack, thebeav ]
+    nodes: [ node1, node2, node3 ]
+  mariobrothers:
+    admins: [ mario, luigi ]
+    users: [ mario, luigi, bowser, toadstool ]
+    nodes: [ node1, node2, node3 ]
+  mixup:
+    admins: [ bowser, thebeav ]
+    users: [ applejack, mario, thebeav, toadstool, bowser]
+    nodes: [ node1, node2, node3 ]
+
+# These users will be created if they don't exist. No knife.rb will
+# be generated for them unless they are part of an org
+users: [unaffiliated]

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -17,6 +17,7 @@ vm:
     - "*.vmdk"
     - "*.plt"
     - "*.beam"
+    - .bundle/
     - rspec.failures
 
 projects:

--- a/dev/dvm/.gitignore
+++ b/dev/dvm/.gitignore
@@ -1,0 +1,3 @@
+.bundle
+bin/thor
+testdata

--- a/dev/dvm/Gemfile
+++ b/dev/dvm/Gemfile
@@ -1,0 +1,5 @@
+# keeping this around for local testing
+gemspec :name => 'dvm.gemspec'
+
+gem "deep_merge", git:  "https://github.com/danielsdeleo/deep_merge.git"
+

--- a/dev/dvm/Gemfile.lock
+++ b/dev/dvm/Gemfile.lock
@@ -1,0 +1,21 @@
+GIT
+  remote: https://github.com/danielsdeleo/deep_merge.git
+  revision: f9df6fdb0d0090318e8015814e68e5ca2973b493
+  specs:
+    deep_merge (1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    highline (1.6.21)
+    mixlib-shellout (2.0.1)
+    thor (0.18.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  deep_merge!
+  highline
+  mixlib-shellout
+  thor

--- a/dev/dvm/bin/dvm
+++ b/dev/dvm/bin/dvm
@@ -1,0 +1,10 @@
+#!/opt/opscode/embedded/bin/ruby
+
+require "dvm"
+
+begin
+  raise DVM::DVMArgumentError, "dvm must be run as root"  unless Process.uid == 0
+  DVM::Application.start(ARGV)
+rescue DVM::DVMArgumentError => e
+  say HighLine.color(e.message, :red)
+end

--- a/dev/dvm/dvm.gemspec
+++ b/dev/dvm/dvm.gemspec
@@ -1,0 +1,16 @@
+Gem::Specification.new do |s|
+  s.name        = 'dvm'
+  s.version     = '100.0.0'
+  s.date        = '2015-03-18'
+  s.summary     = "chef-server development enabler"
+  s.description = "A controller for your friendly local chef-server dev vm. Don't leave home without it!"
+  s.authors     = ["Marc A. Paradise", "Chef Software, Inc"]
+  s.email       = 'marc@chef.io'
+  s.files       = Dir.glob("{bin,lib}/**/*") + [ "parse.es" ]
+  s.executables << 'dvm'
+  s.license       = 'Apache'
+  s.add_dependency "highline"
+  s.add_dependency "thor"
+  s.add_dependency "mixlib-shellout"
+  s.add_dependency "deep_merge"
+end

--- a/dev/dvm/lib/dvm.rb
+++ b/dev/dvm/lib/dvm.rb
@@ -1,0 +1,3 @@
+require_relative "dvm/project"
+require_relative "dvm/application"
+require_relative "dvm/populate"

--- a/dev/dvm/lib/dvm/application.rb
+++ b/dev/dvm/lib/dvm/application.rb
@@ -1,0 +1,178 @@
+ # Interesting to note that thor and highliine are already in our
+# omnibus bundle.
+require "thor"
+require "highline/import"
+require "deep_merge"
+require "yaml"
+
+module DVM
+  PROJECT_CLASSES = {
+    # TODO module Project, class method 'base_name', enumerate and generate...
+    "omnibus" => DVM::OmnibusProject,
+    "erlang" => DVM::ErlangProject,
+    "ruby" => DVM::RubyProject
+  }
+  class DVMArgumentError < ArgumentError
+
+  end
+
+  class Application < Thor
+    def initialize(args, local_options,config)
+      super
+
+      @projects = {}
+      # Note use of hard-coded paths here.  Since I want this installed
+      # as a gem, and to accept modifications at any time to the config files,
+      # and this is intended for use ina  controlled environment - this seems
+      # like the best answer.
+      @config = YAML.load_file("/vagrant/defaults.yml")
+      if File.file? "/vagrant/config.yml"
+        overrides = YAML.load_file("/vagrant/config.yml")
+        @config.deep_merge! overrides
+      end
+      @config["projects"].each do |name, project|
+        type = project["type"]
+        @projects[name] = PROJECT_CLASSES[type].new(name, @config)
+      end
+    end
+
+
+    desc "list [project]", "list available projects, or available dependencies within project"
+    def list(project = nil)
+      if project == nil
+        @projects.each do |name, p|
+          say("#{HighLine.color(name, :green)} #{p.loaded? ? "loaded" : "not_loaded"}")
+        end
+      else
+        say(HighLine.color("#{project} deps:", :bold))
+        project = @projects[project]
+        project.deps.each do |name, dep|
+          status, c = dep.loaded? ? ["loaded", :green] : ["available", :white]
+          say("  #{name}: #{HighLine.color(status, c)}")
+        end
+      end
+    end
+
+    option :"no-build", type: :boolean,
+                        aliases: ['-n'],
+                        desc: "skip the build phase and just load/mount the source path"
+    desc "load <project> [dep-or-sub]", "load a project or project's named dependency"
+    def load(project_name, dep = nil)
+      ensure_project(project_name)
+      project = @projects[project_name]
+      if dep.nil?
+        project.load(options[:"no-build"])
+      else
+        project.load_dep(dep, options[:"no-build"])
+      end
+    end
+
+
+    desc "etop <project>", "run etop to monitor the running project"
+    def etop(project_name)
+      ensure_project(project_name)
+      @projects[project_name].etop
+
+    end
+
+    desc "unload <project> [dep]", "unload a project or a project's named dependency"
+    def unload(project_name, dep = nil)
+      ensure_project(project_name)
+      if dep.nil?
+        @projects[project_name].unload()
+      else
+        @projects[project_name].unload_dep(dep)
+      end
+
+    end
+    desc "update <project> <pause|resume>",  "if the  project supports it, pause or resume sync updates in the running instance"
+    def update(project_name, action)
+      ensure_project(project_name)
+      @projects[project_name].update(action)
+    end
+    desc "runit <project> [run-args]", "Run the project"
+    def runit(project_name, *args)
+      ensure_project(project_name)
+      args = args.nil? ? [] : args
+      @projects[project_name].run args
+    end
+
+    desc "start <project> [run-args]", "Start the service associated with the project, out of the mounted directory. Currently supported for erlang projects only.  Will remain in foreground --background is specified."
+    option :"foreground", type: :boolean,
+                        aliases: ['-b'],
+                        desc: "Launch the server in the background instead of the default behavior of bringing it to the foreground for interactive use"
+    def start(project_name, *args)
+      ensure_project(project_name)
+      args = args.nil? ? [] : args
+      @projects[project_name].start args, options[:background]
+    end
+
+    desc "console <project>", "connect to a running process in a console if the projects supports it and the project service has been started."
+    def console(project_name)
+      ensure_project(project_name)
+      @projects[project_name].console
+    end
+
+    desc "psql <project>", "connect to the database for a project, if it exists"
+    def psql(project_name)
+      ensure_project(project_name)
+      database = @projects[project_name].database
+      exec "sudo -u opscode-pgsql /opt/opscode/embedded/bin/psql #{database}"
+    end
+
+
+    desc "stop <project>", "Stop a running service that has been loaded locally"
+    def stop(project_name)
+      ensure_project(project_name)
+      @projects[project_name].stop
+    end
+
+
+    desc "quickstart [<configname>]", "Execute a quickstart configuration.  Use with no arguments to see what's available"
+    def qs(configname = nil)
+      quickstart(configname)
+    end
+    desc "quickstart [<configname>]", "Execute a quickstart configuration.  Use with no arguments to see what's available"
+    def quickstart(configname = nil)
+      if configname.nil?
+        say "The following quickstart configurations are available:"
+        @config["quickstart"].each do |name, qs|
+          say "  #{name} : #{qs["description"]}"
+        end
+      else
+        # TODO support different quickstart configurations by name (bookshelf, oc-id, etc)
+        qs = @config["quickstart"][configname]
+        raise DVMArgumentError, "No such quickstart configuration found: #{configname}" if qs.nil?
+        puts qs["description"] if qs.has_key? "description"
+        if qs.has_key? "load"
+          qs["load"].each do |project_info|
+            name, args = project_info.split(" ", 2)
+            puts "Loading: #{name}"
+            load(name, args)
+          end
+        end
+        if qs.has_key? "start"
+          qs["start"].each do |project_info|
+            args = project_info.split(" ")
+            DVM::Application.start(["start"] + args)
+          end
+        end
+      end
+    end
+
+    desc "populate", "Create users and orgs as defined in defaults & config yml"
+    def populate
+
+
+    end
+  private
+    def ensure_project(name)
+      raise DVM::DVMArgumentError, "No such project: #{name}" unless @projects.has_key?(name)
+    end
+
+    def ensure_dep(project, dep)
+      raise DVM::DVMArgumentError, "No such dep #{dep} for project #{project}" unless @projects[name].has_dep(dep)
+    end
+  end
+
+end

--- a/dev/dvm/lib/dvm/populate.rb
+++ b/dev/dvm/lib/dvm/populate.rb
@@ -1,0 +1,122 @@
+require "erubis" # available courtesy of chef server.
+require "fileutils"
+
+# Note: we might want to use the API for all this, but for now it's
+# just a glorified shell script
+module DVM
+  class Populator
+    def initialize(orgs, users)
+      @orgs = orgs
+      @users = users
+    end
+    def make_orgs(orgs)
+      FileUtils::mkdir_p '/vagrant/testdata/orgs'
+      orgs.each do |name, data|
+        @current_org = name
+        make_org(data)
+      end
+
+    end
+    def make_users(users)
+      FileUtils::mkdir_p '/vagrant/testdata/keys'
+      users.each do |user|
+        make_user(user)
+      end
+    end
+    def make_org(org)
+      dir = "/vagrant/testdata/orgs/#{name}"
+      FileUtils::mkdir_p dir
+      validator = "#{dir}/#{name}-validator.pem"
+      if File.exists? validator
+        puts "Validator for #{name} exists, skipping org creation"
+      else
+        `chef-server-ctl org-create #{name} #{name} > #{validator}`
+      end
+      org.users.each do |user|
+        make_user(user)
+        add_user_to_org(user, @current_org, false)
+      end
+      org.admins.each do |admin|
+        make_user(user)
+        add_user_to_org(user, @current_org, true)
+      end
+    end
+    def add_user_to_org(username, orgname, admin)
+      userdir = "/vagrant/testsdata/orgs/#{orgname}/#{username}/.chef"
+      if File.exists? userdir
+        puts "Not adding user #{username}, it is already in #{orgname}"
+        return
+      end
+      File.mkdir_p userdir
+      `chef-server-ctl org-user-add #{orgname} #{username} -a #{admin}`
+
+    end
+    def make_user(user)
+      key = user_key_path(user)
+      if file.exists? key
+        puts "Skipping user #{user}, key already exists"
+      else
+        # TODO we probably should care if this fails...
+        `chef-server-ctl user-create #{user} #{user} test-user #{username}@dvm.com password > #{key}`
+      end
+    end
+    def user_key_path(username)
+      "/vagrant/testdata/keys/#{username}.pem"
+    end
+    def validator_key_path
+      "/vagrant/testdata/orgs/#{@current_org}/#{@current_org}-validtor.pemkeys/#{username}.pem"
+    end
+    def client_key_path(orgname, nodename)
+      "/vagrant/testdata/orgs/#{orgname}/nodes/#{nodename}/.chef/#{nodename.pem}"
+    end
+    def kniferb(orgname, username, validatorpath, keypath)
+      <<-EOM
+log_level                :info
+log_location             STDOUT
+node_name                "#{username}"
+client_key               "#{keypath}"
+validation_client_name   "#{@current_org}-validator"
+validation_key           "#{validatorpath}"
+chef_server_url          "https://api.chef-server.dev/organizations/#{orgname}"
+cache_type               'BasicFile'
+cache_options( :path => "/vagrant/testdata/cookbookcache" )
+cookbook_path            ["/vagrant/testdata/cookbooks"]
+ssl_verify_mode  :verify_none
+      EOM
+    end
+    def clientrb(orgname, nodename)
+      <<-EOM
+log_level                :info
+log_location     STDOUT
+client_key       "#{client_key_path(orgname, nodename)}"
+chef_server_url  "https://api.chef-server.dev/organizations/#{orgname}
+validation_client_name "#{orgname}-validator"
+node_name "#{nodename}"
+ssl_verify_mode  :verify_none
+EOM
+
+    end
+  end
+end
+# TODO create dot chef dir
+    # TODO turn of strict host checking in all knife.rbs
+    # TODO knife in path?
+    # TODO pivotal or just use validator?
+    #command "chef-server-ctl user-create #{username} #{username} test-user #{username}@#{orgname}.com password > #{private_key}"
+    #command "knife client create #{nodename} -u #{orgname}-validator -k #{org_validator} -s https://api.chef-server.dev > #{node_key_path}"
+    #command "knife node create #{nodename} -u #{nodename} -k #{node_key_path} -s https://api.chef-server.dev"
+    # Populate .chef/chef.rb for nodes, .chef/knife.rb for users
+    #dot_chef = "#{org_root}/#{nodename}/.chef"
+    #private_key = "#{user_root}/#{nodename}.pem"
+    #template "#{dot_chef}/knife.rb" do
+      #source "knife.rb.erb"
+      #variables(
+        #:username => username,
+        #:orgname => orgname,
+        #:server_fqdn => 'api.chef-server.dev'
+      #)
+      #mode "0777"
+      #action :create
+    #end
+    # knife_command = "/opt/opscode/embedded/knife -s api.chef-server.dev -k /etc/opscode/pivotal.pem"
+

--- a/dev/dvm/lib/dvm/project.rb
+++ b/dev/dvm/lib/dvm/project.rb
@@ -1,0 +1,341 @@
+require "mixlib/shellout"
+
+module DVM
+  class Project
+    attr_reader :name, :project, :config, :service, :project_dir
+
+    # TODO check required fields in config
+    def initialize(project_name, config)
+      @name = project_name
+      @config = config
+      @project = config['projects'][project_name]
+      @service = @project['service']
+      @project_dir = "/host/#{name}"
+    end
+    def self.safe_run_command(command, desc = nil, opts = {})
+      say desc if desc
+      cmd = Mixlib::ShellOut.new(command, opts)
+      cmd.run_command
+      cmd.error!
+    end
+    def self.bind_mount(from, to)
+      safe_run_command "mount -o bind #{from} #{to}"
+    end
+    def self.unmount(from)
+      safe_run_command "umount #{from}"
+    end
+
+    def self.path_mounted?(path)
+      mounts = `mount`
+      mounts.split("\n").each do |mount|
+        if mount.include? path
+          return true
+        end
+      end
+      return false
+    end
+
+    def start(args,odetach)
+      raise DVM::DVMArgumentError, "Start not supported for #{name}"
+    end
+
+    def run(args)
+      raise DVM::DVMArgumentError, "Run not supported for #{name}"
+    end
+
+    def database
+      raise DVM::DVMArgumentError, "No database configured for #{name}" unless @project['database']
+      @project['database']
+    end
+
+    def deps
+      parse_deps
+      @deps
+    end
+
+    def load(build)
+
+    #  parse_deps
+    end
+
+    def loaded?
+      false
+    end
+    def etop
+      raise DVM::DVMArgumentError, "This application does not support etop."
+    end
+
+    def load_dep(name, build)
+      # TODO separate impl so we can ensure parse_deps and "loaded?"
+      raise DVM::DVMArgumentError, "This application does not support loading dependencies."
+    end
+
+    def unload
+      raise "You should implement this now."
+    end
+
+    def update(args)
+      raise DVM::DVMArgumentError, "This project does not support dynamic updates."
+    end
+
+    def console
+      raise DVM::DVMArgumentError, "This project does not support a console."
+    end
+
+    def ensure_dep(name)
+      raise DVM::DVMArgumentError, "This project does not have the dep #{name}" unless deps.has_key? name
+    end
+
+    def parse_deps
+      @deps = {}
+    end
+    def unload_dep(name)
+      raise DVM::DVMArgumentError, "Not yet supported"
+    end
+  end
+
+
+  class ErlangProject < Project
+    class ProjectDep
+      attr_reader :name, :ref, :url, :path
+      def initialize(name, base_dir, data)
+        @url = data["url"]
+        @ref  = data["ref"]
+        @name = name
+        @path = "#{base_dir}/#{name}"
+      end
+      def loaded?
+        File.symlink? path
+      end
+      def load
+      end
+      def unload
+        raise DVMArgumentError,  "#{name} is not loaded" unless loaded?
+        stop() if is_running?
+        Project.unmount(@project_dir)
+        # werlang project: for dep unloading nuke the dep and get-deps, compile seems fastest
+        # unless we want to do the preserve dance.
+      end
+    end
+    attr_reader :rebar_config_path, :project_dir, :relpath
+    def initialize(project_name, config)
+      super
+      # TODO use .lock if available, else use .config
+      @rebar_config_path = "#{project_dir}/rebar.config.lock"
+      reldir = service['rel-type'] == 'relx' ? "_rel" : "rel"
+      @relpath = "#{@project_dir}/#{reldir}/#{name}"
+      @service_dir = "/var/opt/opscode/embedded/service/#{service['name']}"
+    end
+
+    def parse_deps
+      @deps = {}
+      # TODO when project is unloaded, parse.es load might have parse.es in ../..
+      path = File.expand_path("../../../parse.es", __FILE__)
+      eval(`#{path} #{@rebar_config_path}`).each do |name, data|
+        @deps[name] = ProjectDep.new(name, "#{project_dir}/deps", data)
+      end
+    end
+
+    def is_running?
+      `ps waux | grep "host/#{name}.*/run_erl"`.split("\n").length > 2
+    end
+
+    def start(args, background)
+      raise DVMArgumentError, "#{name} appears to be already running. Try 'dvm console oc_erchef', or 'dvm stop oc_erchef'" if is_running?
+      if background
+        Project.safe_run_command("bin/#{name} start -env DEVVM=1", "Starting #{name}", cwd: relpath, env: { "DEVVM" => "1" } )
+      else
+        exec "cd #{relpath} && bin/#{name} console"
+      end
+    end
+    def stop()
+      raise DVMArgumentError, <<-EOM unless is_running?
+"#{name} does not seem to be running from a loaded instance.
+If you want to stop the global instance, use chef-server-ctl stop #{service['name']}'"
+EOM
+      Project.safe_run_command("bin/#{name} stop", "Stoopping #{name}", :cwd => relpath)
+    end
+    def console
+      raise "#{name} does not seem to be running from a loaded instance. Use `dvm start #{name}` to start it" unless is_running?
+      exec "#{erl_command} -remsh #{service["node"]}"
+    end
+    def loaded?
+      return @loaded unless @loaded.nil?
+      libpath =  File.join(@relpath, "lib")
+      # If a devrel has been performed on this box, almost everything in the
+      # lib directory will actually be a symlink to a valid location on this box.
+      # Filter out everything that fits this criteria - if any files remain
+      # then a proper devrel has not been performed.
+      #
+      begin
+        files = Dir.entries(libpath)
+        if files.length < 4
+          @loaded = false
+          @loaded
+        end
+      rescue
+        @loaded = false
+        return @loaded
+      end
+      files.reject! do |fname|
+        fullpath = File.join(libpath, fname)
+        # TODO clean case!
+
+        # special cases, not symlinks:
+        (fname == "patches" or fname == "." or fname == "..") or
+          # all else must be both a symlink and resolve to valid location
+          (File.symlink?(fullpath) and File.file?(fullpath))
+
+      end
+      @loaded = files.length == 0
+      @loaded
+
+    end
+
+    def load_dep(name, build)
+      # TODO wrap this in parent class
+      raise DVM::DVMArgumentError, "Load the project before loading deps." unless loaded?
+      ensure_dep
+
+    end
+
+    def load(no_build = false)
+      raise DVM::DVMArgumentError, "Project not available. Clone it onto your host machine." unless File.directory?(@project_dir)
+      raise DVM::DVMArgumentError, "Project already loaded" if loaded?
+      do_build unless no_build
+      Project.safe_run_command("chef-server-ctl stop #{service['name']}", "Stopping #{service['name']}", cwd: project_dir)
+
+      say("Setting up symlinks")
+      FileUtils.rm_rf(["#{relpath}/log", "#{relpath}/sys.config"])
+      FileUtils.ln_s("/var/opt/opscode/#{service["name"]}/sys.config", "#{relpath}/sys.config")
+      FileUtils.ln_s("/var/log/opscode/#{service["name"]}", "#{relpath}/log")
+
+      say(HighLine.color("Success! Your project is loaded.", :green))
+      say("Start it now:")
+      say(HighLine.color("    dvm start #{name} [--background]", :green))
+    end
+
+    def do_build
+      say("This should take just a couple of minutes")
+      say("Cleaning deps...")
+      FileUtils.rm_rf(["#{project_dir}/deps"])
+      Project.safe_run_command("make clean relclean", "Cleaning up everything else",     cwd: project_dir)
+      Project.safe_run_command("rebar get-deps -C rebar.config.lock",       "Getting all deps, please hold.", cwd: project_dir)
+      Project.safe_run_command("make -j 8 devrel",    "Building, this will take a few.", cwd: project_dir, env: { "USE_SYSTEM_GECODE" => "1"})
+    end
+
+    def enable_cover(modules = nil)
+      # [file:wildcard("/host/oc_erchef/apps/*/ebin")
+      # compile_beam_dir("/host/oc_erchef/apps/
+    end
+    def dump_cover(modules = nil)
+
+    end
+    def update(args)
+      # No running check in case we're trying to attach to the global instance
+      node = service['node']
+      if args == "pause"
+        pause_msg = "Pausing sync on #{node}. This will take effect after any running scans have been completed. \nUse 'dvm update oc_erchef resume' to re-enable automatic updates."
+        Project.safe_run_command("#{erl_command} -eval \"rpc:call('#{node}', sync, pause, []).\" -s erlang halt", pause_msg)
+      elsif args == "resume"
+        Project.safe_run_command("#{erl_command} -eval \"rpc:call('#{node}', sync, go, []).\" -s erlang halt", "Resuming sync on #{node}")
+      end
+    end
+
+    def etop
+      exec "#{erl_command} -s etop -s erlang halt -output text -sort reductions -lines 25 -node #{service['node']}"
+    end
+
+    def erl_command
+      "erl -hidden -name dvm@127.0.0.1 -setcookie #{service["cookie"]}"
+    end
+
+  end
+
+
+  class RubyProject < Project
+    def initialize(project_name, config)
+      super
+    end
+    def load( no_build)
+      if @project.has_key?('load')
+        # TODO this seems like a sane default for load behavior in Project, have it
+        # call subclass do_load if there is no such key. Will also let us quickly get new projects
+        # going.
+        @project['load'].each do |c|
+          Project.safe_run_command(c, c, cwd: @project_dir)
+        end
+      else
+        Project.safe_run_command("rm -rf .bundle/config && bundle install --path /opt/opscode/embedded/service/gem --no-binstubs", "Installing in-place...", cwd: @project_dir)
+      end
+    end
+    def unload
+      say "Unmounting #{name}"
+      Project.unmount(@project_dir)
+    end
+    def loaded?
+      false
+    end
+    def run(args)
+      exec "cd #{@project_dir} && #{@project['run']} #{args.join(" ")}"
+    end
+  end
+
+
+
+  class OmnibusProject < Project
+    class OmnibusDep
+      attr_reader :name, :source_path, :dest_path, :reconfigure_on_load
+      def initialize(name, config)
+        @name = name
+        @source_path = File.join("/host/opscode-omnibus/files", config['source_path'])
+        @dest_path = File.join("/opt/opscode/embedded", config['dest_path'])
+        @reconfigure_on_load = config['reconfigure_on_load']
+      end
+      def unload
+        Project.unmount(source_path)
+        if reconfigure_on_load
+          Project.safe_run_command("chef-server-ctl reconfigure", "Reconfiguring chef server to pick up the changes")
+        end
+      end
+      def load
+        Project.bind_mount(source_path, dest_path)
+        if reconfigure_on_load
+          Project.safe_run_command("chef-server-ctl reconfigure", "Reconfiguring chef server to pick up the changes")
+        end
+      end
+      def loaded?
+        Project.path_mounted? source_path
+      end
+    end
+    def initialize(project_name, config)
+      super
+    end
+    def unload_dep(subname)
+      parse_deps
+      raise DVMArgumentError, "Could not find sub-project #{subname}" unless  @deps.has_key? subname
+      dep = @deps[subname]
+      raise DVMArgumentError, "#{subname} is not loaded." unless dep.loaded?
+      dep.unload
+    end
+    def load_dep(subname, ignored)
+      parse_deps
+      raise DVMArgumentError, "Could not find sub-project #{subname}" unless  @deps.has_key? subname
+      dep = @deps[subname]
+      raise DVMArgumentError, "#{subname} is already loaded." if dep.loaded?
+      dep.load
+    end
+    def parse_deps()
+      #  for us, deps are more subprojects.
+      if @deps.nil?
+        @deps = {}
+        @project['components'].each do |sub, c|
+          @deps[sub] = OmnibusDep.new(sub, c)
+        end
+      end
+    end
+    def loaded?
+      File.directory? @project_dir
+    end
+  end
+end

--- a/dev/dvm/parse.es
+++ b/dev/dvm/parse.es
@@ -1,0 +1,30 @@
+#!/usr/bin/env escript
+
+% This simple script will parse the deps section of a rebar.config and spit out
+% a ruby hash. Used for automatic dependency loading and linking of erlang projects
+main([]) ->
+  io:fwrite("Usage: ./parse.es rebar.config-path");
+main([FileName|_]) ->
+    {ok, Terms} = file:consult(FileName),
+    Deps = proplists:get_value(deps, Terms),
+    Values = [ {Name, Location}   || {Name, _, Location} <- Deps ],
+    Rubified = [term_to_ruby_hash(V) || V <- Values ],
+    io:fwrite("{~s}~n", [string:join(Rubified, ",")]).
+
+term_to_ruby_hash({Name, {git, URL}}) ->
+    io_lib:format("\"~s\" => { \"url\" => \"~s\", \"ref\" => \"HEAD\" } ", [Name, URL]);
+term_to_ruby_hash({Name, {git, URL, ""}}) ->
+    io_lib:format("\"~s\" => { \"url\" => \"~s\", \"ref\" => \"HEAD\" } ", [Name, URL]);
+term_to_ruby_hash({Name, {git, URL, "master"}}) ->
+    io_lib:format("\"~s\" => { \"url\" => \"~s\", \"ref\" => \"origin/master\" } ", [Name, URL]);
+term_to_ruby_hash({Name, {git, URL, {tag, Tag} } } )->
+    io_lib:format("\"~s\" => { \"url\" => \"~s\", \"ref\" => \"~s\" } ", [Name, URL, Tag]);
+term_to_ruby_hash({Name, {git, URL, {branch, Branch} } } )->
+    io_lib:format("\"~s\" => { \"url\" => \"~s\", \"ref\" => \"origin/~s\" } ", [Name, URL, Branch]);
+term_to_ruby_hash({Name, {git, URL, Ref}}) ->
+    io_lib:format("\"~s\" => { \"url\" => \"~s\", \"ref\" => \"~s\" } ", [Name, URL, Ref ]).
+
+
+
+
+

--- a/rebar.config
+++ b/rebar.config
@@ -70,7 +70,9 @@
         {opscoderl_httpc, ".*",
          {git, "https://github.com/opscode/opscoderl_httpc", {branch, "master"}}},
         {uuid, ".*",
-         {git, "https://github.com/okeuday/uuid", {tag, "v1.3.2"}}}
+         {git, "https://github.com/okeuday/uuid", {tag, "v1.3.2"}}},
+        {sync, ".*",
+         {git, "https://github.com/rustyio/sync.git", {branch, "master"}}}
        ]}.
 
 %% Set this to true if you will build OTP releases of this project via

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -123,6 +123,9 @@
        {uuid,".*",
              {git,"https://github.com/okeuday/uuid",
                   "f7c141c8359cd690faba0d2684b449a07db8e915"}},
+       {sync, ".*",
+             {git,"https://github.com/rustyio/sync.git",
+                  "ae7dbd4e6e2c08d77d96fc4c2bc2b6a3b266492b"}},
        {rebar_lock_deps_plugin,".*",
                                {git,"git://github.com/seth/rebar_lock_deps_plugin.git",
                                     "7a5835029c42b8138325405237ea7e8516a84800"}}]}.

--- a/relx.config
+++ b/relx.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
-{release,{oc_erchef,"1.6.4"},[oc_erchef]}.
+{release,{oc_erchef,"1.6.4"},[oc_erchef, syntax_tools, compiler]}.
 {extended_start_script,true}.
 {overlay_vars,"rel/reltool.config"}.
 {overlay,[{mkdir,"log/sasl"},

--- a/src/oc_erchef.app.src
+++ b/src/oc_erchef.app.src
@@ -14,26 +14,21 @@
                   chef_objects,
                   depsolver,
                   oc_chef_authz,
-                  oc_chef_wm
+                  oc_chef_wm,
 
                   %% TODO: The following deps should be pulled in by the above
                   %% apps, but they aren't. Isn't that sad? We should fix it!
-                  ,
                   bear,
                   chef_authn,
-                  %% edoc,
                   ej,
                   envy,
                   eper,
                   erlware_commons,
                   et,
-                  %% eunit,
                   folsom_graphite,
                   gs,
-                  %% hipe,
                   jiffy,
                   mini_s3,
-                  %% mnesia,
                   oauth,
                   observer,
                   opscoderl_folsom,
@@ -43,7 +38,11 @@
                   tools,
                   uuid,
                   webtool,
-                  wx
+                  %% These are effectively dev-only, but need to be present as apps pulled into the
+                  %% development environment by relx.  mixer is not startable, and sync is only started when
+                  %% DEVVM=1 environment variable is present.
+                  sync,
+                  mixer
                  ]},
   {mod, { oc_erchef_app, []}},
   {env, []}

--- a/src/oc_erchef_app.erl
+++ b/src/oc_erchef_app.erl
@@ -10,6 +10,11 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
+    case os:getenv("DEVVM") of
+        "1" ->
+            application:start(sync);
+        _ -> ok
+    end,
     oc_erchef_sup:start_link().
 
 stop(_State) ->


### PR DESCRIPTION
This self-contained environment is a simple vagrant environment,
bundled with a tool internally that can be used to load, run, and
test oc_erchef and related components.

This is another step along the road to make getting started with chef-server
development as painless as possible.

It still has some odd behaviors but is generally working quite well.  
There are still minor warts, and the ruby part can be made a lot cleaner, but nothing unforgivable.  The best way to get feedback on it is to get it out there, so I'd like to get this merged in and into the hands of people in need. 

Note: In light of @stevendanna's work, it may be this is best served as a top-level project under 'chef-server' once that lands.   Once this is in, I'll likely revisit when I can to add kitchen support if the benefits outweigh the time investment. 

As far as I know this should be runnable by anyone with github access, with no org-internal dependences on chef.io


ping @chef/lob 

---- 

Quick Start: 


Give it a spin! Make sure you have a current chef-server-core deb available in Downloads or opscode-omnibus/pkg and you should have a relatively recent vagrant (1.7+) and virtualbox (4.3 latest). It may work elsewhere but I haven't tested it. 

To start: 
 `cd dev; vagrant up`. 

After it's online: 
`cd dev; vagrant rsync-auto` and let  that run in its own shell - this keeps your files sync'd from the host, and seems to be  fast  and have low resource utilization. 

vagrant ssh into the shell, then:

```
sudo -i
dvm quickstart oc_erchef
``` 
This will do the necessary builds and configuration and dump you into a running oc_erchef shell.   It assumes you have a current opscode-omnibus and oc-chef-pedant available in the same directory that contains oc_erchef.  - if you don't, you can instead `dvm load oc_erchef` to load only oc_erchef. 

--- 
Perf Notes: in general, this is a faster environment, mostly because it's using rsync instead of shared directories.  A full run of pedant completes in about 25 minutes with this configuration on my box, while the 'dvm load oc_erchef' action takes about 2-4 minutes (compared to 5-6 to rake project:load[oc_erchef]). 

Other Notes: 
- still need to make sure other projects like bifrost and bookshelf load in properly, but I expect minimal changes there. 
- in practice I found I only periodically use the default users/orgs that dev-vm provides, so they're not created yet. I'm in the process of adding a 'dvm populate' command which will do this, using orgs/users/nodes specified in `defaults.yml`. 
- `config.yml` is intended to be an override to `defaults.yml`. In generally you can add to/replace anything that's in `defaults.yml`, but it won't yet work for anything under the heading "vm". 

It's also possible to load in chef-server-ctl commands, ha cookbooks, and partybus upgrades. To 

`dvm load omnibus $SUBPROJECT`
Where $SUBPROJECT is ctl-commands, ha-drdb-cookbook, or upgrades. You can also find the names of projects/subprojects using `dvm list` or `dvm list projectname`