### PR TITLE
Squelches a lot of the same dialyzer errors

### DIFF
--- a/apps/oc_chef_wm/src/chef_wm.erl
+++ b/apps/oc_chef_wm/src/chef_wm.erl
@@ -24,6 +24,8 @@
 -type base_state() :: #base_state{}.
 -type resource_state() :: term().
 
+-export_type([http_verb/0, base_state/0, auth_info_return/0]).
+
 -callback init(list()) ->
     {ok, base_state()} | error().
 
@@ -39,7 +41,9 @@
 -callback request_type() ->
     string().
 
--callback auth_info(wm_req(), base_state()) ->
+-callback auth_info(wm_req(), base_state()) -> auth_info_return().
+
+-type auth_info_return() ::
     {{halt, non_neg_integer()}, wm_req(), base_state()} |
     {{halt, non_neg_integer(), binary()}, wm_req(), base_state()} |
     {{create_in_container, container_name()}, wm_req(), base_state()} |
@@ -54,4 +58,3 @@
     {{container_id, object_id()}, wm_req(), base_state()} |
     {{group, object_id()}, wm_req(), base_state()} |
     {{group_id, object_id()}, wm_req(), base_state()}.
-

--- a/apps/oc_chef_wm/src/chef_wm_clients.erl
+++ b/apps/oc_chef_wm/src/chef_wm_clients.erl
@@ -77,6 +77,8 @@ allowed_methods(Req, State) ->
 %% We set up the state such that the superuser avoids the ACL checks.
 %% FIXME: This is a temporary fix until pedant uses the validator which has
 %% permissions to create a new client
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{organization_guid = OrgId} = State) ->
     %% Put a stub chef_client record into the resource_state. This allows us to use shared
     %% code for generating the map of name => URL returned for GET /clients.  OrgId is set via

--- a/apps/oc_chef_wm/src/chef_wm_cookbook_version.erl
+++ b/apps/oc_chef_wm/src/chef_wm_cookbook_version.erl
@@ -62,6 +62,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET', 'PUT', 'DELETE'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request(Method, Req, #base_state{resource_state = CBState0} = State) ->
     UrlName = chef_wm_util:extract_from_path(cookbook_name, Req),
     UrlVersion = chef_wm_util:extract_from_path(cookbook_version, Req),

--- a/apps/oc_chef_wm/src/chef_wm_cookbooks.erl
+++ b/apps/oc_chef_wm/src/chef_wm_cookbooks.erl
@@ -60,6 +60,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{resource_state = CBState0} = State) ->
     NumVersions = chef_wm_util:num_versions(Req),
     CBState = CBState0#cookbook_state{num_versions=NumVersions},

--- a/apps/oc_chef_wm/src/chef_wm_data.erl
+++ b/apps/oc_chef_wm/src/chef_wm_data.erl
@@ -67,6 +67,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET','POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{organization_guid = OrgId} = State) ->
     %% Put a stub chef_data record into the resource_state. This allows us to use shared
     %% code for generating the map of name => URL returned for GET /datas.  OrgId is set via

--- a/apps/oc_chef_wm/src/chef_wm_environment_cookbooks.erl
+++ b/apps/oc_chef_wm/src/chef_wm_environment_cookbooks.erl
@@ -57,6 +57,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{resource_state=EnvironmentState}=State) ->
     %% We need to figure out which cookbook, if any, we're restricting results to to figure
     %% out what value of 'num_versions' to use, so we might as well stick this into the

--- a/apps/oc_chef_wm/src/chef_wm_environment_recipes.erl
+++ b/apps/oc_chef_wm/src/chef_wm_environment_recipes.erl
@@ -62,6 +62,8 @@ malformed_request_message(Any, _Req, _State) ->
 
 %% TODO: This is the same as in named_environment_resource and
 %% environment_cookbooks_resource... consider consolidating
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, #base_state{chef_db_context = DbContext,
                            organization_guid = OrgId,
                            resource_state = EnvState} = State) ->

--- a/apps/oc_chef_wm/src/chef_wm_environment_roles.erl
+++ b/apps/oc_chef_wm/src/chef_wm_environment_roles.erl
@@ -61,6 +61,8 @@ allowed_methods(Req, State) ->
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
 
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, #base_state{chef_db_context = DbContext,
                            organization_guid = OrgId,
                            resource_state = RoleState} = State) ->

--- a/apps/oc_chef_wm/src/chef_wm_environments.erl
+++ b/apps/oc_chef_wm/src/chef_wm_environments.erl
@@ -63,6 +63,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['POST', 'GET'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{organization_guid = OrgId} = State) ->
     %% Put a stub chef_environment record into the resource_state. This allows us to use shared
     %% code for generating the map of name => URL returned for GET /environments.  OrgId is set via

--- a/apps/oc_chef_wm/src/chef_wm_named_environment.erl
+++ b/apps/oc_chef_wm/src/chef_wm_named_environment.erl
@@ -69,6 +69,8 @@ allowed_methods(Req, State) ->
     Req1 = chef_wm_util:set_json_body(Req, {[{<<"error">>, [Msg]}]}),
     {Methods, Req1, State#base_state{resource_state = #environment_state{}}}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('PUT', Req, State) ->
     Body = wrq:req_body(Req),
     {ok, Environment} = chef_environment:parse_binary_json(Body),

--- a/apps/oc_chef_wm/src/chef_wm_named_node.erl
+++ b/apps/oc_chef_wm/src/chef_wm_named_node.erl
@@ -69,6 +69,8 @@ validate_request('PUT', Req, #base_state{resource_state = NodeState} = State) ->
     {Req, State#base_state{resource_state = NodeState#node_state{node_data = Node}}}.
 
 %% Memoize the container id so we don't hammer the database
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, #base_state{chef_db_context = DbContext,
                            organization_guid = OrgId,
                            resource_state = NodeState} = State) ->

--- a/apps/oc_chef_wm/src/chef_wm_named_role.erl
+++ b/apps/oc_chef_wm/src/chef_wm_named_role.erl
@@ -48,8 +48,6 @@
          resource_exists/2,
          to_json/2]).
 
-
-
 init(Config) ->
     oc_chef_wm_base:init(?MODULE, Config).
 
@@ -83,6 +81,8 @@ validate_request('PUT', Req, #base_state{resource_state = RoleState} = State) ->
     {Req, State#base_state{resource_state = RoleState#role_state{role_data = Role}}}.
 
 %% Memoize the container id so we don't hammer the database
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, #base_state{chef_db_context = DbContext,
                            resource_state = RoleState,
                            organization_guid = OrgId} = State) ->

--- a/apps/oc_chef_wm/src/chef_wm_named_sandbox.erl
+++ b/apps/oc_chef_wm/src/chef_wm_named_sandbox.erl
@@ -113,6 +113,8 @@ from_json(Req, #base_state{reqid = ReqId,
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('PUT', Req, State) ->
     %% it's OK if this throws, will be handled by caller of validate_request/2.
     Body = chef_json:decode(wrq:req_body(Req)),

--- a/apps/oc_chef_wm/src/chef_wm_roles.erl
+++ b/apps/oc_chef_wm/src/chef_wm_roles.erl
@@ -64,6 +64,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET','POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{organization_guid = OrgId} = State) ->
     %% Put a stub chef_role record into the resource_state. This allows us to use shared
     %% code for generating the map of name => URL returned for GET /roles.  OrgId is set via

--- a/apps/oc_chef_wm/src/chef_wm_sandboxes.erl
+++ b/apps/oc_chef_wm/src/chef_wm_sandboxes.erl
@@ -59,6 +59,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('POST', Req, #base_state{resource_state = BoxState} = State) ->
     {ok, Sandbox} = chef_sandbox:parse_binary_json(wrq:req_body(Req), create),
     {Req, State#base_state{resource_state = BoxState#sandbox_state{sandbox_data = Sandbox}}}.

--- a/apps/oc_chef_wm/src/chef_wm_search.erl
+++ b/apps/oc_chef_wm/src/chef_wm_search.erl
@@ -70,6 +70,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET','POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, State) ->
     Query = make_query_from_params(Req),
     SearchState = #search_state{solr_query = Query},

--- a/apps/oc_chef_wm/src/oc_chef_wm_acl.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_acl.erl
@@ -69,6 +69,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{chef_db_context = DbContext,
                                          organization_guid = OrgId,
                                          organization_name = OrgName,

--- a/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
@@ -60,6 +60,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['PUT'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('PUT', Req, #base_state{chef_db_context = DbContext,
                                          organization_guid = OrgId,
                                          organization_name = OrgName,

--- a/apps/oc_chef_wm/src/oc_chef_wm_authenticate_user.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_authenticate_user.erl
@@ -42,6 +42,8 @@ request_type() ->
 allowed_methods(Req, State) ->
   {['POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('POST', Req, #base_state{resource_state = UserState} = State) ->
   case wrq:req_body(Req) of
       Body  when Body == undefined orelse Body == <<>> ->

--- a/apps/oc_chef_wm/src/oc_chef_wm_containers.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_containers.erl
@@ -47,6 +47,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET', 'POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{organization_guid = OrgId} = State) ->
     {Req, State#base_state{resource_state = #oc_chef_container{org_id = OrgId}}};
 validate_request('POST', Req, #base_state{resource_state = ContainerState}= State) ->

--- a/apps/oc_chef_wm/src/oc_chef_wm_controls.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_controls.erl
@@ -54,6 +54,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('POST', Req, #base_state{resource_state = ControlState} = State) ->
     Body = wrq:req_body(Req),
     Data = chef_json:decode(Body),
@@ -156,4 +158,3 @@ routing_key() ->
 
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
-

--- a/apps/oc_chef_wm/src/oc_chef_wm_groups.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_groups.erl
@@ -50,6 +50,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET', 'POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{organization_guid = OrgId} = State) ->
     {Req, State#base_state{superuser_bypasses_checks = true,
                            resource_state = #oc_chef_group{org_id = OrgId}}};

--- a/apps/oc_chef_wm/src/oc_chef_wm_keys.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_keys.erl
@@ -63,6 +63,8 @@ allowed_methods(Req, State) ->
     {['GET', 'POST'], Req, State}.
 
 %% This export is mixed into oc_chef_wm_named_key -
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('PUT', Req, #base_state{resource_args = ObjectType, chef_db_context = Ctx, organization_guid = OrgId} = State) ->
     EJ = chef_key:parse_binary_json(wrq:req_body(Req), update),
     ObjectName = chef_wm_util:object_name(ObjectType, Req),

--- a/apps/oc_chef_wm/src/oc_chef_wm_named_container.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_named_container.erl
@@ -44,10 +44,14 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET', 'DELETE'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request(Method, Req, State) when Method == 'GET';
                                           Method == 'DELETE' ->
     {Req, State}.
 
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, #base_state{chef_db_context = DbContext,
                            resource_state = ContainerState,
                            organization_guid = OrgId} =State) ->

--- a/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact.erl
@@ -40,6 +40,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET'], Req, State}.
 
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, #base_state{organization_guid = OrgId,
                            chef_db_context = DbContext,
                            resource_args = single_artifact} = State) ->

--- a/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact_version.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact_version.erl
@@ -52,6 +52,8 @@ create_path(Req, State) ->
 resource_exists(Req, State) ->
     {true, Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('PUT', Req, #base_state{resource_state = CAVState} = State) ->
     CAVData = validate_json(Req),
     NewResourceState = CAVState#cookbook_artifact_version_state{cookbook_artifact_version_data = CAVData},

--- a/apps/oc_chef_wm/src/oc_chef_wm_named_group.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_named_group.erl
@@ -60,6 +60,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET', 'PUT', 'DELETE'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request(Method, Req, State = #base_state{organization_guid = OrgId}) when Method == 'GET';
                                           Method == 'DELETE' ->
     {Req, State#base_state{superuser_bypasses_checks = true, resource_state = #group_state{oc_chef_group = #oc_chef_group{org_id = OrgId}}}};

--- a/apps/oc_chef_wm/src/oc_chef_wm_named_organization.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_named_organization.erl
@@ -47,6 +47,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET', 'PUT', 'DELETE'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request(Method, Req, State = #base_state{organization_guid = OrgId}) when Method == 'GET';
                                                                                    Method == 'DELETE' ->
     {Req, State#base_state{superuser_bypasses_checks = true, resource_state = #organization_state{oc_chef_organization = #oc_chef_organization{id = OrgId}}}};

--- a/apps/oc_chef_wm/src/oc_chef_wm_named_policy.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_named_policy.erl
@@ -53,6 +53,8 @@ create_path(Req, State) ->
     Name = wrq:path_info(policy_name, Req),
     {Name, Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request(Method, Req,
                  State = #base_state{organization_guid = OrgId})
   when Method == 'GET'; Method == 'DELETE' ->
@@ -293,4 +295,3 @@ delete_resource(Req, #base_state{chef_db_context = DbContext,
 
 malformed_request_message(Any, _Req, _state) ->
     error({unexpected_malformed_request_message, Any}).
-

--- a/apps/oc_chef_wm/src/oc_chef_wm_org_associations.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_org_associations.erl
@@ -67,6 +67,8 @@ allowed_methods(Req, State) ->
     end,
     {Allowed, Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('POST', Req, #base_state{chef_db_context = DbContext} = State) ->
     {ok, EJ} = oc_chef_org_user_association:parse_binary_json(wrq:req_body(Req)),
     UserName = ej:get({<<"username">>}, EJ),

--- a/apps/oc_chef_wm/src/oc_chef_wm_org_invites.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_org_invites.erl
@@ -75,7 +75,13 @@ validate_request('POST', Req, #base_state{chef_db_context = DbContext} = State) 
                                                                    data = EJ}}}
     end.
 
-auth_info(Req, #base_state{resource_state = #association_state{org_user_invite = not_found}} = State) ->
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
+auth_info(Req, #base_state{
+                  resource_state = #association_state{
+                                      org_user_invite = not_found
+                                     }
+                 } = State) ->
     Id = chef_wm_util:object_name(invitation, Req),
     Message = chef_wm_util:not_found_message(invitation, Id),
     Req1 = chef_wm_util:set_json_body(Req, Message),

--- a/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
@@ -62,6 +62,8 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET', 'POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{organization_guid = OrgId, server_api_version = ApiVersion} = State) ->
     {Req, State#base_state{resource_state = #oc_chef_organization{id = OrgId, server_api_version = ApiVersion}}};
 validate_request('POST', Req, #base_state{resource_state = OrganizationState}= State) ->
@@ -69,9 +71,13 @@ validate_request('POST', Req, #base_state{resource_state = OrganizationState}= S
     {ok, EJson} = oc_chef_organization:parse_binary_json(Body),
     {Req, State#base_state{resource_state = OrganizationState#organization_state{organization_data = EJson}}}.
 
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, State) ->
     auth_info(wrq:method(Req), Req, State).
 
+-spec auth_info(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info('GET', Req, State) ->
     {{container, organization}, Req, State};
 auth_info('POST', Req, State) ->

--- a/apps/oc_chef_wm/src/oc_chef_wm_policies.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_policies.erl
@@ -44,13 +44,19 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['GET'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('GET', Req, #base_state{organization_guid = OrgId} = State) ->
     {Req, State#base_state{superuser_bypasses_checks = true,
                            resource_state = #oc_chef_policy{org_id = OrgId}}}.
 
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, State) ->
     auth_info(wrq:method(Req), Req, State).
 
+-spec auth_info(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info('GET', Req, State ) ->
     {{container, policies}, Req, State}.
 

--- a/apps/oc_chef_wm/src/oc_chef_wm_system_recovery.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_system_recovery.erl
@@ -43,6 +43,8 @@ request_type() ->
 allowed_methods(Req, State) ->
   {['POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('POST', Req, #base_state{resource_state = UserState} = State) ->
   case wrq:req_body(Req) of
       Body  when Body == undefined orelse Body == <<>> ->
@@ -116,4 +118,3 @@ auth_fail_message(403) ->
     chef_wm_util:error_message_envelope(<<"System recovery disabled for this user">>);
 auth_fail_message(502) ->
     chef_wm_util:error_message_envelope(<<"Authentication server is unavailable.">>).
-

--- a/apps/oc_chef_wm/src/oc_chef_wm_users.erl
+++ b/apps/oc_chef_wm/src/oc_chef_wm_users.erl
@@ -52,6 +52,8 @@ request_type() ->
 allowed_methods(Req, State) ->
   {['GET', 'POST'], Req, State}.
 
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
 validate_request('POST', Req, #base_state{server_api_version = ApiVersion} = State) ->
   case wrq:req_body(Req) of
     undefined ->
@@ -64,9 +66,13 @@ validate_request('POST', Req, #base_state{server_api_version = ApiVersion} = Sta
 validate_request('GET', Req, State) ->
     {Req, State}.
 
+-spec auth_info(wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info(Req, State) ->
     auth_info(wrq:method(Req), Req, State).
 
+-spec auth_info(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                       chef_wm:auth_info_return().
 auth_info('GET', Req, State) ->
     {{container, user}, Req, State};
 auth_info('POST', Req, State) ->

--- a/include/oc_chef_wm.hrl
+++ b/include/oc_chef_wm.hrl
@@ -71,7 +71,10 @@
                           role |
                           client |
                           container |
-                          sandbox.
+                          sandbox |
+                          policies |
+                          user |
+                          organization.
 
 -type auth_tuple() :: {object, object_id(), permission()} |
                       {container, container_name(), permission()}.


### PR DESCRIPTION
The behaviour callbacks in chef_wm for auth_info/2 and
validate_request/3 weren't picking up the right base_state() data type
in the modules that implemented them.