### PR TITLE
Add chef_db:bulk_fetch_cookbook_versions for use in chef_wm_depsolver

### DIFF
--- a/apps/chef_db/priv/pgsql_statements.config
+++ b/apps/chef_db/priv/pgsql_statements.config
@@ -358,6 +358,26 @@
     FROM joined_cookbook_version
     WHERE org_id = $1">>}.
 
+%% Used in implementation of environemnts/ENVNAME/cookbook_versions endpoint.
+%%
+%% Depends on the cbv type existing in the schema
+{bulk_fetch_cookbook_versions,
+ <<"WITH inputs AS ( select * from unnest($2::cbv[]) )
+  SELECT v.id,  v.major, v.minor, v.patch, v.frozen, v.meta_attributes,
+         v.meta_deps, v.meta_long_desc, v.metadata, v.serialized_object,
+         v.last_updated_by, v.created_at, v.updated_at, c.authz_id, c.org_id, c.name,
+         (SELECT ARRAY(SELECT checksum FROM cookbook_version_checksums cvc
+                       WHERE org_id = $1 AND cvc.cookbook_version_id = v.id)) checksums
+    FROM inputs,
+         cookbooks as c,
+         cookbook_versions as v
+   WHERE c.org_id = $1
+     AND inputs.name = c.name
+     AND v.cookbook_id = c.id
+     AND v.major = inputs.major
+     AND v.minor = inputs.minor
+     AND v.patch = inputs.patch">>}.
+
 %% Used in implementation of environments/ENVIRONMENT/recipes endpoint
 %%
 %% This query shouldn't use the `cookbook_versions_by_rank' view, even

--- a/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -248,7 +248,7 @@ handle_depsolver_results(ok, {error, {unreachable_package, Unreachable}}, Req, S
 handle_depsolver_results(ok, {ok, Cookbooks}, Req, #base_state{chef_db_context = DbContext,
                                                                organization_name = OrgName} = State) ->
     %% TODO - helper function to deal with the call and match on a chef_cookbook version
-    CookbookRecords = [ chef_db:fetch_cookbook_version(DbContext, OrgName, Cookbook) || Cookbook <- Cookbooks],
+    CookbookRecords = chef_db:bulk_fetch_cookbook_versions(DbContext, OrgName, Cookbooks),
     assemble_response(Req, State, CookbookRecords).
 
 %% @doc Utility function to remove some of the verbosity

--- a/schema/deploy/cbv_type.sql
+++ b/schema/deploy/cbv_type.sql
@@ -1,0 +1,13 @@
+-- Deploy cbv_type
+
+BEGIN;
+-- PostgreSQL doesn't support a CREATE TYPE IF NOT EXISTS statement
+-- thus we drop and then add inside the transaction.
+DROP TYPE IF EXISTS cbv;
+CREATE TYPE cbv AS (
+       name text,
+       major bigint,
+       minor bigint,
+       patch bigint
+);
+COMMIT;

--- a/schema/revert/cbv_type.sql
+++ b/schema/revert/cbv_type.sql
@@ -1,0 +1,7 @@
+-- Revert cbv_type
+
+BEGIN;
+
+DROP TYPE IF EXISTS cbv;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -71,3 +71,6 @@ policy_groups [policies] 2015-02-27T22:52:25Z Daniel DeLeo <ddeleo@lorentz.local
 policy_revisions [policy_groups] 2015-02-27T23:39:16Z Daniel DeLeo <ddeleo@lorentz.local># Create separte policy revisions table
 policy_revisions_policy_groups_association 2015-03-05T20:57:56Z Daniel DeLeo <ddeleo@lorentz.local># Add join between policy groups and revisions
 @policyfile-api-tables 2015-04-16T19:48:36Z Daniel DeLeo <ddeleo@lorentz.local> # Add policyfile endpoint tables
+
+cbv_type 2015-04-23T08:33:00Z Steven Danna <steve@chef.io> # Add cbv type for new bulk_fetch_cookbook_versions query
+@cbv-type 2015-04-23T08:34:00Z Steven Danna <steve@chef.io> # Add cbv type for new bulk_fetch_cookbook_versions query

--- a/schema/t/test_cbv_type.sql
+++ b/schema/t/test_cbv_type.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION test_cbv_type()
+RETURNS SETOF TEXT
+LANGUAGE plpgsql
+AS $$
+
+BEGIN
+  RETURN QUERY SELECT has_type( 'cbv' );
+  RETURN QUERY SELECT has_column( 'cbv', 'name');
+  RETURN QUERY SELECT col_type_is('cbv', 'name', 'text');
+  RETURN QUERY SELECT has_column( 'cbv', 'major');
+  RETURN QUERY SELECT col_type_is('cbv', 'major', 'bigint');
+  RETURN QUERY SELECT has_column( 'cbv', 'minor');
+  RETURN QUERY SELECT col_type_is('cbv', 'minor', 'bigint');
+  RETURN QUERY SELECT has_column( 'cbv', 'patch');
+  RETURN QUERY SELECT col_type_is('cbv', 'patch', 'bigint');
+END;
+
+$$;

--- a/schema/verify/cbv_type.sql
+++ b/schema/verify/cbv_type.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'cbv');
+
+ROLLBACK;


### PR DESCRIPTION
Currently, we make 3 SQL queries per cookbook returned by depsolver.
chef_db:bulk_fetch_cookbook_version allows us to get the same data via
2 total queries, regardless of the number of cookbooks returned by
depsolver.

This should reduce the stress that the cookbook_versions endpoint
places on postgresql in large installations.