### PR TITLE
Allow empty cookbook artifacts to be found in DB

### DIFF
--- a/apps/oc_chef_authz/src/oc_chef_authz_db.erl
+++ b/apps/oc_chef_authz/src/oc_chef_authz_db.erl
@@ -228,12 +228,13 @@ statements(pgsql) ->
         "FROM cookbook_artifact_versions AS cav "
         "JOIN cookbook_artifacts AS ca "
           "ON cav.cookbook_artifact_id = ca.id "
-        "JOIN cookbook_artifact_version_checksums AS cavc "
+        "LEFT JOIN cookbook_artifact_version_checksums AS cavc "
           "ON cavc.cookbook_artifact_version_id = cav.id "
        "WHERE ca.org_id = $1 "
          "AND ca.name = $2 "
          "AND cav.identifier = $3 "
     "GROUP BY cav.id, ca.org_id, ca.name, ca.authz_id">>},
+
       {delete_cookbook_artifact_version_by_id,
        <<"SELECT * FROM delete_cookbook_artifact_version($1)">>},
       {list_cookbook_artifacts_by_org_id,


### PR DESCRIPTION
Previously a cookbook artifact with no associated checksums would not be
found by our query, resulting in incorrect 404s for cookbook artifacts that exist but don't have any files.

Fix is verified by pedant tests which will be forthcoming.