### PR TITLE
Bump release versions to 1.8.3

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -1,5 +1,5 @@
 {sys,[{lib_dirs,["../deps","../apps"]},
-      {rel,"oc_erchef","1.8.2",
+      {rel,"oc_erchef","1.8.3",
            [kernel,stdlib,sasl,crypto,mochiweb,webmachine,ejson,oauth,ibrowse,
             couchbeam,lager,epgsql,sqerl,rabbit_common,amqp_client,gen_bunny,
             chef_index,darklaunch,oc_chef_wm,opscoderl_wm,opscoderl_httpc,

--- a/relx.config
+++ b/relx.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
-{release,{oc_erchef,"1.6.4"},[oc_erchef, syntax_tools, compiler]}.
+{release,{oc_erchef,"1.8.3"},[oc_erchef, syntax_tools, compiler]}.
 {extended_start_script,true}.
 {overlay_vars,"rel/reltool.config"}.
 {overlay,[{mkdir,"log/sasl"},


### PR DESCRIPTION
I couldn't get rebar to do this in the correct way so I just edited the files by hand. Did I miss anything?

@chef/lob 